### PR TITLE
AIR-009.1: Add archive storage configuration for gold parquet output (Without tests)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,9 @@ DATA_DIR=/app/data
 RAW_DIR=/app/data/raw
 GOLD_DIR=/app/data/gold
 
+# Archive storage (local or azure)
+ARCHIVE_STORAGE=local
+
 # Optional Postgres load
 USE_POSTGRES=0
 POSTGRES_HOST=postgres

--- a/services/pipeline/src/pipeline/common/config.py
+++ b/services/pipeline/src/pipeline/common/config.py
@@ -21,6 +21,9 @@ class Settings(BaseSettings):
     postgres_user: str = "cityair"
     postgres_password: str = "cityair"
 
+    # Archive storage
+    archive_storage: str = "local"
+
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 
 

--- a/services/pipeline/src/pipeline/load/storage.py
+++ b/services/pipeline/src/pipeline/load/storage.py
@@ -7,8 +7,14 @@ from ..common.config import settings
 
 
 def publish_outputs(gold_df: pd.DataFrame, gold_dir: Path, table_name: str) -> Path:
-    gold_path = gold_dir / f"{table_name}.parquet"
-    gold_df.to_parquet(gold_path, index=False)
+
+    if settings.archive_storage == "local":
+        gold_path = gold_dir / f"{table_name}.parquet"
+        gold_df.to_parquet(gold_path, index=False)
+    elif settings.archive_storage == "azure":
+        raise NotImplementedError("Azure storage is not implemented yet.")
+    else:
+        raise ValueError(f"Unsupported archive storage: {settings.archive_storage}")
 
     if settings.use_postgres:
         engine = create_engine(


### PR DESCRIPTION
**Implementations for #29**

1. Update pipeline settings in `services/pipeline/src/pipeline/common/config.py`
- Added `archive_storage: str = "local"`

2. Update the load layer in `services/pipeline/src/pipeline/load/storage.py`
- Kept the current local parquet writing behavior as the default path
- Added logic that checks `settings.archive_storage`
  - Expected behavior:
    - if `archive_storage == "local"`:
      - continue writing `gold_dir / f"{table_name}.parquet"`
    - if `archive_storage == "azure"`:
      - raise a clear `NotImplementedError`
- Kept Postgres publishing behavior unchanged

3. Update `.env.example`
- Added `ARCHIVE_STORAGE=local`
