### PR TITLE
AIR-011.1a: add APScheduler-compatible runner scaffold

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ requests>=2.32
 pydantic>=2.7
 pydantic-settings>=2.3
 python-dotenv>=1.0
+APScheduler>=3.10
 duckdb>=1.0
 sqlalchemy>=2.0
 psycopg[binary]>=3.2

--- a/services/pipeline/src/pipeline/orchestration.py
+++ b/services/pipeline/src/pipeline/orchestration.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pandas as pd
+
+from .common.config import settings
+from .common.logging import get_logger
+from .extract.cities import read_cities
+from .extract.geocoding import geocode_city
+from .extract.openweather_air_pollution import fetch_air_pollution_history
+from .load.storage import publish_outputs
+from .transform.openweather_air_pollution_transform import build_gold_from_raw
+
+
+log = get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class PipelineRunResult:
+    run_id: str
+    source: str
+    history_hours: int
+    raw_files: list[Path]
+    gold_path: Path
+    rows: int
+
+
+def ensure_output_directories() -> tuple[Path, Path]:
+    raw_dir = Path(settings.raw_dir)
+    gold_dir = Path(settings.gold_dir)
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    gold_dir.mkdir(parents=True, exist_ok=True)
+    return raw_dir, gold_dir
+
+
+def build_runtime_window(history_hours: int) -> tuple[datetime, datetime]:
+    end = datetime.now(timezone.utc)
+    start = end - timedelta(hours=history_hours)
+    return start, end
+
+
+def run_extract_stage(raw_dir: Path, start: datetime, end: datetime, run_id: str) -> list[Path]:
+    cities = read_cities(Path(settings.cities_file))
+    raw_files: list[Path] = []
+
+    for city in cities:
+        coords = geocode_city(
+            raw_dir=raw_dir,
+            city=city.city,
+            country_code=city.country_code,
+            state=city.state,
+        )
+        raw_path = fetch_air_pollution_history(
+            raw_dir=raw_dir,
+            city=city.city,
+            country_code=city.country_code,
+            lat=coords.lat,
+            lon=coords.lon,
+            start=start,
+            end=end,
+            run_id=run_id,
+        )
+        raw_files.append(raw_path)
+
+    return raw_files
+
+
+def run_transform_stage(raw_files: list[Path]) -> pd.DataFrame:
+    return build_gold_from_raw(raw_files=raw_files)
+
+
+def run_load_stage(gold_df: pd.DataFrame, gold_dir: Path, table_name: str = "air_pollution_gold") -> Path:
+    return publish_outputs(gold_df=gold_df, gold_dir=gold_dir, table_name=table_name)
+
+
+def run_pipeline_job(source: str = "openweather", history_hours: int | None = None) -> PipelineRunResult:
+    resolved_history_hours = int(settings.history_hours if history_hours is None else history_hours)
+    raw_dir, gold_dir = ensure_output_directories()
+    start, end = build_runtime_window(resolved_history_hours)
+    run_id = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+    log.info("Starting pipeline", extra={"source": source, "history_hours": resolved_history_hours})
+
+    raw_files = run_extract_stage(raw_dir=raw_dir, start=start, end=end, run_id=run_id)
+    gold_df = run_transform_stage(raw_files=raw_files)
+    gold_path = run_load_stage(gold_df=gold_df, gold_dir=gold_dir)
+
+    result = PipelineRunResult(
+        run_id=run_id,
+        source=source,
+        history_hours=resolved_history_hours,
+        raw_files=raw_files,
+        gold_path=gold_path,
+        rows=len(gold_df),
+    )
+
+    log.info("Pipeline complete", extra={"gold_path": str(result.gold_path), "rows": result.rows})
+    return result

--- a/services/pipeline/tests/test_orchestration_runner.py
+++ b/services/pipeline/tests/test_orchestration_runner.py
@@ -1,0 +1,78 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+from src.pipeline.extract.cities import CitySpec
+from src.pipeline.orchestration import PipelineRunResult, run_pipeline_job
+import src.pipeline.orchestration as orchestration
+
+
+def test_run_pipeline_job_is_importable_and_returns_result(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    monkeypatch.setattr(orchestration.settings, "cities_file", str(tmp_path / "cities.csv"))
+    monkeypatch.setattr(orchestration.settings, "raw_dir", str(tmp_path / "raw"))
+    monkeypatch.setattr(orchestration.settings, "gold_dir", str(tmp_path / "gold"))
+
+    captured: dict[str, object] = {}
+
+    def fake_read_cities(path: Path) -> list[CitySpec]:
+        captured["cities_path"] = path
+        return [CitySpec(city="Toronto", country_code="CA", state="ON")]
+
+    def fake_fetch_air_pollution_history(**kwargs):
+        captured["fetch_kwargs"] = kwargs
+        return tmp_path / "raw" / "x.json"
+
+    def fake_build_gold_from_raw(*, raw_files: list[Path]) -> pd.DataFrame:
+        captured["raw_files"] = raw_files
+        return pd.DataFrame([{"geo_id": "Toronto,CA", "ts": "2026-03-17T00:00:00Z"}])
+
+    def fake_publish_outputs(**kwargs):
+        captured["publish_kwargs"] = kwargs
+        return tmp_path / "gold" / "air_pollution_gold.parquet"
+
+    monkeypatch.setattr(orchestration, "read_cities", fake_read_cities)
+    monkeypatch.setattr(orchestration, "geocode_city", lambda **_: SimpleNamespace(lat=43.6535, lon=-79.3839))
+    monkeypatch.setattr(orchestration, "fetch_air_pollution_history", fake_fetch_air_pollution_history)
+    monkeypatch.setattr(orchestration, "build_gold_from_raw", fake_build_gold_from_raw)
+    monkeypatch.setattr(orchestration, "publish_outputs", fake_publish_outputs)
+
+    result = run_pipeline_job(source="openweather", history_hours=72)
+
+    assert isinstance(result, PipelineRunResult)
+    assert result.source == "openweather"
+    assert result.history_hours == 72
+    assert result.rows == 1
+    assert result.gold_path == tmp_path / "gold" / "air_pollution_gold.parquet"
+    assert captured["cities_path"] == tmp_path / "cities.csv"
+    assert captured["raw_files"] == [tmp_path / "raw" / "x.json"]
+    assert isinstance(captured["publish_kwargs"]["gold_df"], pd.DataFrame)
+    assert captured["publish_kwargs"]["gold_dir"] == tmp_path / "gold"
+    assert captured["publish_kwargs"]["table_name"] == "air_pollution_gold"
+
+
+def test_run_pipeline_job_fails_fast_when_cities_file_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    missing_path = tmp_path / "missing-cities.csv"
+
+    monkeypatch.setattr(orchestration.settings, "cities_file", str(missing_path))
+    monkeypatch.setattr(orchestration.settings, "raw_dir", str(tmp_path / "raw"))
+    monkeypatch.setattr(orchestration.settings, "gold_dir", str(tmp_path / "gold"))
+
+    geocode_called = {"value": False}
+
+    def should_not_be_called(**_):
+        geocode_called["value"] = True
+        return SimpleNamespace(lat=0.0, lon=0.0)
+
+    monkeypatch.setattr(orchestration, "geocode_city", should_not_be_called)
+
+    with pytest.raises(FileNotFoundError, match=r"CITIES_FILE path does not exist") as error:
+        run_pipeline_job()
+
+    assert str(missing_path) in str(error.value)
+    assert geocode_called["value"] is False


### PR DESCRIPTION
## Summary
- add APScheduler as a project dependency
- add a minimal APScheduler-compatible orchestration module with run_pipeline_job(...)
- add isolated tests for the new orchestration entrypoint

## Notes
- this keeps the current CLI path unchanged for AIR-011.1a
- no ETL business logic or output locations were changed

## Testing
- PYTHONPATH=services/pipeline pytest services/pipeline/tests/test_orchestration_runner.py
- PYTHONPATH=services/pipeline pytest services/pipeline/tests