### PR TITLE
AIR-011: package pipeline and add module entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ These scripts:
 - create `.venv` in the project root if missing
 - upgrade `pip`, `setuptools`, and `wheel`
 - install dependencies from `requirements.txt`
+- install the local pipeline package in editable mode for module-based execution
 
 ### WSL, Linux, or macOS
 
@@ -51,6 +52,14 @@ After script setup, activate the environment:
 
 - WSL, Linux, macOS: `source .venv/bin/activate`
 - Windows PowerShell: `.venv\Scripts\Activate.ps1`
+
+Run the pipeline locally with the package entrypoint:
+
+```bash
+python -m pipeline.cli --source openweather --history-hours 72
+```
+
+This is the preferred local run path because it matches the packaged production-style entrypoint used by the pipeline service.
 
 ## Configure cities
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - ./configs:/app/configs:ro
     depends_on:
       - postgres
-    command: ["python", "run_pipeline.py", "--source", "openweather", "--history-hours", "72"]
+    command: ["python", "-m", "pipeline.cli", "--source", "openweather", "--history-hours", "72"]
     restart: "no"
 
   dashboard:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "city-air-tracker-pipeline"
+version = "0.1.0"
+description = "City Air Tracker pipeline package"
+requires-python = ">=3.11"
+
+[project.scripts]
+city-air-pipeline = "pipeline.cli:main"
+
+[tool.setuptools]
+package-dir = {"" = "services/pipeline/src"}
+
+[tool.setuptools.packages.find]
+where = ["services/pipeline/src"]

--- a/scripts/setup_venv.ps1
+++ b/scripts/setup_venv.ps1
@@ -37,11 +37,12 @@ try {
 
     & $VenvPython -m pip install --upgrade pip setuptools wheel
     & $VenvPython -m pip install -r requirements.txt
+    & $VenvPython -m pip install --no-build-isolation -e .
 
     Write-Host ""
     Write-Host "Setup complete."
     Write-Host "Activate with: .venv\Scripts\Activate.ps1"
-    Write-Host "Run pipeline: python services/pipeline/run_pipeline.py --source openweather --history-hours 72"
+    Write-Host "Run pipeline: python -m pipeline.cli --source openweather --history-hours 72"
     Write-Host "Run dashboard: streamlit run services/dashboard/app/Home.py"
 }
 finally {

--- a/scripts/setup_venv.sh
+++ b/scripts/setup_venv.sh
@@ -33,9 +33,10 @@ source "$VENV_DIR/bin/activate"
 
 python -m pip install --upgrade pip setuptools wheel
 python -m pip install -r requirements.txt
+python -m pip install --no-build-isolation -e .
 
 echo
 echo "Setup complete."
 echo "Activate with: source .venv/bin/activate"
-echo "Run pipeline: python services/pipeline/run_pipeline.py --source openweather --history-hours 72"
+echo "Run pipeline: python -m pipeline.cli --source openweather --history-hours 72"
 echo "Run dashboard: streamlit run services/dashboard/app/Home.py"

--- a/services/pipeline/Dockerfile
+++ b/services/pipeline/Dockerfile
@@ -9,8 +9,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir -r /app/requirements.txt
 
+COPY pyproject.toml /app/pyproject.toml
 COPY services/pipeline /app
 COPY configs /app/configs
+RUN pip install --no-cache-dir --no-build-isolation --no-deps /app
 
 ENV PYTHONUNBUFFERED=1
-CMD ["python", "run_pipeline.py", "--source", "openweather", "--history-hours", "72"]
+CMD ["python", "-m", "pipeline.cli", "--source", "openweather", "--history-hours", "72"]

--- a/services/pipeline/run_pipeline.py
+++ b/services/pipeline/run_pipeline.py
@@ -1,66 +1,6 @@
-import argparse
-from pathlib import Path
-from datetime import datetime, timedelta, timezone
+from __future__ import annotations
 
-from src.pipeline.common.config import settings
-from src.pipeline.common.logging import get_logger
-from src.pipeline.extract.cities import read_cities
-from src.pipeline.extract.geocoding import geocode_city
-from src.pipeline.extract.openweather_air_pollution import fetch_air_pollution_history
-from src.pipeline.transform.openweather_air_pollution_transform import build_gold_from_raw
-from src.pipeline.load.storage import publish_outputs
-
-
-log = get_logger(__name__)
-
-
-def main() -> None:
-    parser = argparse.ArgumentParser(description="City Air Tracker ETL pipeline")
-    parser.add_argument("--source", default="openweather", choices=["openweather"])
-    parser.add_argument("--history-hours", type=int, default=int(settings.history_hours))
-    args = parser.parse_args()
-
-    raw_dir = Path(settings.raw_dir)
-    gold_dir = Path(settings.gold_dir)
-    raw_dir.mkdir(parents=True, exist_ok=True)
-    gold_dir.mkdir(parents=True, exist_ok=True)
-
-    end = datetime.now(timezone.utc)
-    start = end - timedelta(hours=args.history_hours)
-
-    log.info("Starting pipeline", extra={"source": args.source, "history_hours": args.history_hours})
-
-    cities = read_cities(Path(settings.cities_file))
-    run_id = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-
-    # Extract
-    raw_files = []
-    for c in cities:
-        coords = geocode_city(
-            raw_dir=raw_dir,
-            city=c.city,
-            country_code=c.country_code,
-            state=c.state,
-        )
-        raw_path = fetch_air_pollution_history(
-            raw_dir=raw_dir,
-            city=c.city,
-            country_code=c.country_code,
-            lat=coords.lat,
-            lon=coords.lon,
-            start=start,
-            end=end,
-            run_id=run_id,
-        )
-        raw_files.append(raw_path)
-
-    # Transform
-    gold_df = build_gold_from_raw(raw_files=raw_files)
-
-    # Load
-    gold_path = publish_outputs(gold_df=gold_df, gold_dir=gold_dir, table_name="air_pollution_gold")
-
-    log.info("Pipeline complete", extra={"gold_path": str(gold_path), "rows": len(gold_df)})
+from pipeline.cli import main
 
 
 if __name__ == "__main__":

--- a/services/pipeline/src/pipeline/cli.py
+++ b/services/pipeline/src/pipeline/cli.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import argparse
+
+from pipeline.common.config import settings
+from pipeline.orchestration import run_pipeline_job
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="City Air Tracker ETL pipeline")
+    parser.add_argument("--source", default="openweather", choices=["openweather"])
+    parser.add_argument("--history-hours", type=int, default=int(settings.history_hours))
+    args = parser.parse_args()
+    run_pipeline_job(source=args.source, history_hours=args.history_hours)
+
+
+if __name__ == "__main__":
+    main()

--- a/services/pipeline/tests/conftest.py
+++ b/services/pipeline/tests/conftest.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+PIPELINE_ROOT = Path(__file__).resolve().parents[1]
+PIPELINE_SRC = PIPELINE_ROOT / "src"
+
+for path in (PIPELINE_SRC, PIPELINE_ROOT):
+    path_str = str(path)
+    if path_str not in sys.path:
+        sys.path.insert(0, path_str)

--- a/services/pipeline/tests/test_cities.py
+++ b/services/pipeline/tests/test_cities.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-from src.pipeline.extract.cities import CitySpec, read_cities
+from pipeline.extract.cities import CitySpec, read_cities
 
 
 def test_read_cities_skips_blank_required_values(tmp_path: Path):

--- a/services/pipeline/tests/test_orchestration_runner.py
+++ b/services/pipeline/tests/test_orchestration_runner.py
@@ -4,9 +4,9 @@ from types import SimpleNamespace
 import pandas as pd
 import pytest
 
-from src.pipeline.extract.cities import CitySpec
-from src.pipeline.orchestration import PipelineRunResult, run_pipeline_job
-import src.pipeline.orchestration as orchestration
+from pipeline.extract.cities import CitySpec
+from pipeline.orchestration import PipelineRunResult, run_pipeline_job
+import pipeline.orchestration as orchestration
 
 
 def test_run_pipeline_job_is_importable_and_returns_result(

--- a/services/pipeline/tests/test_run_pipeline_cities_file.py
+++ b/services/pipeline/tests/test_run_pipeline_cities_file.py
@@ -1,68 +1,41 @@
 from argparse import Namespace
-from pathlib import Path
-from types import SimpleNamespace
-
-import pandas as pd
 import pytest
 
+import pipeline.cli as pipeline_cli
 import run_pipeline
-from src.pipeline.extract.cities import CitySpec
 
 
-def test_main_honors_configured_cities_file(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
-    cities_path = tmp_path / "custom-cities.csv"
-    cities_path.write_text("city,country_code,state\nToronto,CA,ON\n", encoding="utf-8")
-
-    monkeypatch.setattr(run_pipeline.settings, "cities_file", str(cities_path))
-    monkeypatch.setattr(run_pipeline.settings, "raw_dir", str(tmp_path / "raw"))
-    monkeypatch.setattr(run_pipeline.settings, "gold_dir", str(tmp_path / "gold"))
-
+def test_main_routes_cli_arguments_through_shared_runner(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(
-        run_pipeline.argparse.ArgumentParser,
+        pipeline_cli.argparse.ArgumentParser,
         "parse_args",
         lambda self: Namespace(source="openweather", history_hours=72),
     )
 
-    captured: dict[str, Path] = {}
+    captured: dict[str, object] = {}
 
-    def fake_read_cities(path: Path) -> list[CitySpec]:
-        captured["path"] = path
-        return [CitySpec(city="Toronto", country_code="CA", state="ON")]
+    def fake_run_pipeline_job(*, source: str, history_hours: int):
+        captured["source"] = source
+        captured["history_hours"] = history_hours
 
-    monkeypatch.setattr(run_pipeline, "read_cities", fake_read_cities)
-    monkeypatch.setattr(run_pipeline, "geocode_city", lambda **_: SimpleNamespace(lat=43.6535, lon=-79.3839))
-    monkeypatch.setattr(run_pipeline, "fetch_air_pollution_history", lambda **_: tmp_path / "raw" / "x.json")
-    monkeypatch.setattr(run_pipeline, "build_gold_from_raw", lambda **_: pd.DataFrame([{"geo_id": "Toronto,CA", "ts": "2026-03-17T00:00:00Z"}]))
-    monkeypatch.setattr(run_pipeline, "publish_outputs", lambda **_: tmp_path / "gold" / "air_pollution_gold.parquet")
+    monkeypatch.setattr(pipeline_cli, "run_pipeline_job", fake_run_pipeline_job)
 
     run_pipeline.main()
 
-    assert captured["path"] == cities_path
+    assert captured == {"source": "openweather", "history_hours": 72}
 
 
-def test_main_fails_fast_when_cities_file_missing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
-    missing_path = tmp_path / "missing-cities.csv"
-
-    monkeypatch.setattr(run_pipeline.settings, "cities_file", str(missing_path))
-    monkeypatch.setattr(run_pipeline.settings, "raw_dir", str(tmp_path / "raw"))
-    monkeypatch.setattr(run_pipeline.settings, "gold_dir", str(tmp_path / "gold"))
-
+def test_main_propagates_runner_failures(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(
-        run_pipeline.argparse.ArgumentParser,
+        pipeline_cli.argparse.ArgumentParser,
         "parse_args",
         lambda self: Namespace(source="openweather", history_hours=72),
     )
 
-    geocode_called = {"value": False}
+    def fake_run_pipeline_job(*, source: str, history_hours: int):
+        raise FileNotFoundError("CITIES_FILE path does not exist: missing-cities.csv")
 
-    def should_not_be_called(**_):
-        geocode_called["value"] = True
-        return SimpleNamespace(lat=0.0, lon=0.0)
+    monkeypatch.setattr(pipeline_cli, "run_pipeline_job", fake_run_pipeline_job)
 
-    monkeypatch.setattr(run_pipeline, "geocode_city", should_not_be_called)
-
-    with pytest.raises(FileNotFoundError, match=r"CITIES_FILE path does not exist") as error:
+    with pytest.raises(FileNotFoundError, match=r"CITIES_FILE path does not exist"):
         run_pipeline.main()
-
-    assert str(missing_path) in str(error.value)
-    assert geocode_called["value"] is False

--- a/services/pipeline/tests/test_transform_basic.py
+++ b/services/pipeline/tests/test_transform_basic.py
@@ -3,7 +3,7 @@ import json
 from datetime import datetime, timezone
 import pandas as pd
 
-from src.pipeline.transform.openweather_air_pollution_transform import build_gold_from_raw
+from pipeline.transform.openweather_air_pollution_transform import build_gold_from_raw
 
 
 def test_build_gold_from_raw_parses_list(tmp_path: Path):


### PR DESCRIPTION
## Summary
- package the pipeline as an installable Python project with pyproject.toml
- add pipeline.cli as the production-style module entrypoint
- update Docker, compose, local setup scripts, README, and tests to use the package-based layout

## Testing
- .venv/bin/python -m pip install --no-build-isolation -e .
- .venv/bin/pytest services/pipeline/tests
- .venv/bin/python -m pipeline.cli --help
- .venv/bin/python services/pipeline/run_pipeline.py --help