### PR TITLE
AIR-012.2 Add Alembic migrations bootstrap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,7 @@ POSTGRES_PORT=5432
 POSTGRES_DB=cityair
 POSTGRES_USER=cityair
 POSTGRES_PASSWORD=cityair
+ALEMBIC_DATABASE_URL=
 
 # ---- Dashboard ----
 DASHBOARD_DATA_PATH=/app/data/gold/air_pollution_gold.parquet

--- a/README.md
+++ b/README.md
@@ -61,6 +61,24 @@ python -m pipeline.cli --source openweather --history-hours 72
 
 This is the preferred local run path because it matches the packaged production-style entrypoint used by the pipeline service.
 
+## PostgreSQL schema bootstrap
+
+The PostgreSQL-first migration path uses Alembic for schema versioning.
+
+Apply the latest schema locally with:
+
+```bash
+alembic upgrade head
+```
+
+If you are using Docker Compose, run the dedicated migration service:
+
+```bash
+docker compose run --rm migrate
+```
+
+This creates or upgrades the PostgreSQL schema before pipeline services depend on it.
+
 ## Configure cities
 
 The pipeline reads target cities from `CITIES_FILE`.
@@ -120,5 +138,6 @@ Browse `docs/README.md` for the full categorized index.
 - `docs/collaboration/what_is_a_data_pipeline.md`
 - `docs/architecture/architecture.md`
 - `docs/architecture/data_flow_diagram.md`
+- `docs/architecture/postgresql_schema_design.md`
 - `docs/reference/data_dictionary.md`
 - `docs/reference/openweather_environmental_api_fields_reference.md`

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,39 @@
+[alembic]
+script_location = migrations
+prepend_sys_path = .
+sqlalchemy.url = postgresql+psycopg://cityair:cityair@localhost:5432/cityair
+
+[post_write_hooks]
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,14 @@
 services:
+  migrate:
+    build:
+      context: .
+      dockerfile: services/pipeline/Dockerfile
+    env_file: .env
+    depends_on:
+      - postgres
+    command: ["alembic", "upgrade", "head"]
+    restart: "no"
+
   pipeline:
     build:
       context: .
@@ -9,6 +19,7 @@ services:
       - ./configs:/app/configs:ro
     depends_on:
       - postgres
+      - migrate
     command: ["python", "-m", "pipeline.cli", "--source", "openweather", "--history-hours", "72"]
     restart: "no"
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ The `docs/` folder is organized by purpose so contributors can find the right st
 Use these docs when you want to install, run, debug, or validate the project locally.
 
 - `setup/run_and_debug_guide.md`
+- `setup/postgresql_migrations_guide.md`
 - `setup/docker_and_compose_walkthrough.md`
 - `setup/github_quality_gates_setup.md`
 

--- a/docs/setup/postgresql_migrations_guide.md
+++ b/docs/setup/postgresql_migrations_guide.md
@@ -1,0 +1,90 @@
+# PostgreSQL Migrations Guide
+
+This guide explains the migration and bootstrap workflow introduced for `AIR-012.2`.
+
+## Migration tool
+
+This project uses Alembic for PostgreSQL schema versioning.
+
+Alembic is configured at the repository root:
+
+- `alembic.ini`
+- `migrations/env.py`
+- `migrations/versions/`
+
+## Database URL resolution
+
+Alembic resolves the target database in this order:
+
+1. `ALEMBIC_DATABASE_URL`, if set
+2. the PostgreSQL connection values already defined in `.env`
+
+That means the normal application settings can drive migrations without adding a second required database configuration path.
+
+## Local bootstrap
+
+To create or upgrade the schema locally:
+
+```bash
+alembic upgrade head
+```
+
+To inspect the current migration state:
+
+```bash
+alembic current
+```
+
+To view migration history:
+
+```bash
+alembic history
+```
+
+## Docker Compose bootstrap
+
+The repository includes a dedicated `migrate` service:
+
+```bash
+docker compose run --rm migrate
+```
+
+That service runs:
+
+```bash
+alembic upgrade head
+```
+
+The pipeline service depends on the migration service so schema bootstrap can happen before pipeline execution.
+
+## Baseline schema
+
+The baseline migration creates:
+
+- `cities`
+- `geocoding_cache`
+- `pipeline_runs`
+- `raw_air_pollution_responses`
+- `air_pollution_gold`
+
+These tables match the schema design in `docs/architecture/postgresql_schema_design.md`.
+
+## Fresh-database validation
+
+The expected bootstrap validation flow is:
+
+1. start PostgreSQL
+2. run `alembic upgrade head`
+3. verify the migration completes without error
+4. verify the expected tables exist
+
+Example table check:
+
+```bash
+psql postgresql://cityair:cityair@localhost:5432/cityair -c "\\dt"
+```
+
+## Notes
+
+- The baseline migration is the first schema version for the PostgreSQL-first MVP.
+- Later schema changes should be added as new Alembic revision files rather than editing the baseline migration after it has been applied in shared environments.

--- a/docs/setup/run_and_debug_guide.md
+++ b/docs/setup/run_and_debug_guide.md
@@ -14,6 +14,7 @@ These are the Python dependencies currently declared in `requirements.txt`:
 - `python-dotenv>=1.0`
 - `duckdb>=1.0`
 - `sqlalchemy>=2.0`
+- `alembic>=1.13`
 - `psycopg[binary]>=3.2`
 - `streamlit>=1.36`
 - `plotly>=5.22`
@@ -25,7 +26,8 @@ What they are used for on this branch:
 - `requests`: OpenWeather API calls
 - `pydantic`, `pydantic-settings`, `python-dotenv`: environment/config loading
 - `duckdb`: included as a dependency, not currently required by the main runtime path
-- `sqlalchemy`, `psycopg[binary]`: optional Postgres publishing
+- `sqlalchemy`, `psycopg[binary]`: PostgreSQL connectivity
+- `alembic`: PostgreSQL schema versioning and bootstrap
 - `streamlit`, `plotly`: dashboard
 - `pytest`: tests
 

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import os
+import sys
+from logging.config import fileConfig
+from pathlib import Path
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PIPELINE_SRC = ROOT / "services" / "pipeline" / "src"
+if str(PIPELINE_SRC) not in sys.path:
+    sys.path.insert(0, str(PIPELINE_SRC))
+
+from pipeline.common.config import settings
+
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = None
+
+
+def get_database_url() -> str:
+    # Allow an explicit override for migration workflows, otherwise reuse app settings.
+    return os.getenv("ALEMBIC_DATABASE_URL") or settings.postgres_sqlalchemy_url
+
+
+def run_migrations_offline() -> None:
+    context.configure(
+        url=get_database_url(),
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+        compare_type=True,
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    configuration = config.get_section(config.config_ini_section, {})
+    configuration["sqlalchemy.url"] = get_database_url()
+
+    connectable = engine_from_config(
+        configuration,
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata, compare_type=True)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/migrations/script.py.mako
+++ b/migrations/script.py.mako
@@ -1,0 +1,17 @@
+"""${message}"""
+
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/migrations/versions/20260405_000001_air_012_2_baseline_schema.py
+++ b/migrations/versions/20260405_000001_air_012_2_baseline_schema.py
@@ -1,0 +1,148 @@
+"""AIR-012.2 baseline PostgreSQL schema."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260405_000001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "cities",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("city", sa.Text(), nullable=False),
+        sa.Column("country_code", sa.Text(), nullable=False),
+        sa.Column("state", sa.Text(), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+    )
+    op.create_index(
+        "uq_cities_city_country_state",
+        "cities",
+        ["city", "country_code", "state"],
+        unique=True,
+        postgresql_nulls_not_distinct=True,
+    )
+
+    op.create_table(
+        "geocoding_cache",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("city_id", sa.BigInteger(), nullable=False),
+        sa.Column("query_text", sa.Text(), nullable=False),
+        sa.Column("lat", sa.Numeric(9, 6), nullable=False),
+        sa.Column("lon", sa.Numeric(9, 6), nullable=False),
+        sa.Column("provider_name", sa.Text(), nullable=True),
+        sa.Column("provider_state", sa.Text(), nullable=True),
+        sa.Column("provider_country", sa.Text(), nullable=True),
+        sa.Column("fetched_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["city_id"], ["cities.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint("city_id", name="uq_geocoding_cache_city_id"),
+    )
+
+    op.create_table(
+        "pipeline_runs",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("run_id", sa.Text(), nullable=False),
+        sa.Column("source", sa.Text(), nullable=False),
+        sa.Column("history_hours", sa.Integer(), nullable=False),
+        sa.Column("window_start_utc", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("window_end_utc", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("status", sa.Text(), nullable=False),
+        sa.Column("city_count", sa.Integer(), nullable=True),
+        sa.Column("raw_response_count", sa.Integer(), nullable=True),
+        sa.Column("gold_row_count", sa.Integer(), nullable=True),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.UniqueConstraint("run_id", name="uq_pipeline_runs_run_id"),
+    )
+
+    op.create_table(
+        "raw_air_pollution_responses",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("pipeline_run_id", sa.BigInteger(), nullable=False),
+        sa.Column("city_id", sa.BigInteger(), nullable=False),
+        sa.Column("geo_id", sa.Text(), nullable=False),
+        sa.Column("lat", sa.Numeric(9, 6), nullable=False),
+        sa.Column("lon", sa.Numeric(9, 6), nullable=False),
+        sa.Column("request_url", sa.Text(), nullable=False),
+        sa.Column("request_start_utc", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("request_end_utc", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("status_code", sa.Integer(), nullable=False),
+        sa.Column("record_count", sa.Integer(), nullable=False),
+        sa.Column("payload_json", sa.JSON(), nullable=False),
+        sa.Column("fetched_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["pipeline_run_id"], ["pipeline_runs.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["city_id"], ["cities.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint(
+            "city_id",
+            "request_start_utc",
+            "request_end_utc",
+            name="uq_raw_air_pollution_city_window",
+        ),
+    )
+    op.create_index(
+        "ix_raw_air_pollution_responses_pipeline_run_id",
+        "raw_air_pollution_responses",
+        ["pipeline_run_id"],
+        unique=False,
+    )
+
+    op.create_table(
+        "air_pollution_gold",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("pipeline_run_id", sa.BigInteger(), nullable=False),
+        sa.Column("raw_response_id", sa.BigInteger(), nullable=True),
+        sa.Column("city_id", sa.BigInteger(), nullable=False),
+        sa.Column("ts", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("city", sa.Text(), nullable=False),
+        sa.Column("country_code", sa.Text(), nullable=False),
+        sa.Column("lat", sa.Numeric(9, 6), nullable=False),
+        sa.Column("lon", sa.Numeric(9, 6), nullable=False),
+        sa.Column("geo_id", sa.Text(), nullable=False),
+        sa.Column("aqi", sa.Integer(), nullable=True),
+        sa.Column("co", sa.Numeric(12, 4), nullable=True),
+        sa.Column("no", sa.Numeric(12, 4), nullable=True),
+        sa.Column("no2", sa.Numeric(12, 4), nullable=True),
+        sa.Column("o3", sa.Numeric(12, 4), nullable=True),
+        sa.Column("so2", sa.Numeric(12, 4), nullable=True),
+        sa.Column("nh3", sa.Numeric(12, 4), nullable=True),
+        sa.Column("pm2_5", sa.Numeric(12, 4), nullable=True),
+        sa.Column("pm10", sa.Numeric(12, 4), nullable=True),
+        sa.Column("pm2_5_24h_avg", sa.Numeric(12, 4), nullable=True),
+        sa.Column("aqi_category", sa.Text(), nullable=False),
+        sa.Column("risk_score", sa.Numeric(12, 4), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["pipeline_run_id"], ["pipeline_runs.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["raw_response_id"], ["raw_air_pollution_responses.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["city_id"], ["cities.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint("geo_id", "ts", name="uq_air_pollution_gold_geo_id_ts"),
+    )
+    op.create_index("ix_air_pollution_gold_city_id", "air_pollution_gold", ["city_id"], unique=False)
+    op.create_index("ix_air_pollution_gold_ts", "air_pollution_gold", ["ts"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_air_pollution_gold_ts", table_name="air_pollution_gold")
+    op.drop_index("ix_air_pollution_gold_city_id", table_name="air_pollution_gold")
+    op.drop_table("air_pollution_gold")
+
+    op.drop_index("ix_raw_air_pollution_responses_pipeline_run_id", table_name="raw_air_pollution_responses")
+    op.drop_table("raw_air_pollution_responses")
+
+    op.drop_table("pipeline_runs")
+    op.drop_table("geocoding_cache")
+
+    op.drop_index("uq_cities_city_country_state", table_name="cities")
+    op.drop_table("cities")

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ python-dotenv>=1.0
 APScheduler>=3.10
 duckdb>=1.0
 sqlalchemy>=2.0
+alembic>=1.13
 psycopg[binary]>=3.2
 streamlit>=1.36
 plotly>=5.22

--- a/services/pipeline/src/pipeline/common/config.py
+++ b/services/pipeline/src/pipeline/common/config.py
@@ -23,5 +23,12 @@ class Settings(BaseSettings):
 
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 
+    @property
+    def postgres_sqlalchemy_url(self) -> str:
+        return (
+            f"postgresql+psycopg://{self.postgres_user}:{self.postgres_password}"
+            f"@{self.postgres_host}:{self.postgres_port}/{self.postgres_db}"
+        )
+
 
 settings = Settings()

--- a/services/pipeline/tests/test_postgres_config.py
+++ b/services/pipeline/tests/test_postgres_config.py
@@ -1,0 +1,15 @@
+from pipeline.common.config import Settings
+
+
+def test_postgres_sqlalchemy_url_uses_postgres_settings():
+    settings = Settings(
+        postgres_host="db.example",
+        postgres_port=6543,
+        postgres_db="analytics",
+        postgres_user="cityair",
+        postgres_password="secret",
+    )
+
+    assert settings.postgres_sqlalchemy_url == (
+        "postgresql+psycopg://cityair:secret@db.example:6543/analytics"
+    )


### PR DESCRIPTION
## Summary

Implements `AIR-012.2` by adding PostgreSQL schema versioning and bootstrap support for the DB-first pipeline migration.

This PR introduces Alembic-based migration scaffolding, adds the baseline schema migration for the PostgreSQL tables defined in `AIR-012.1`, and documents how to bootstrap or upgrade the schema in local and Docker workflows.

## What Changed

- added `alembic` as the migration/versioning tool
- added a reusable PostgreSQL SQLAlchemy URL helper in pipeline config
- added Alembic project files:
  - `alembic.ini`
  - `migrations/env.py`
  - `migrations/script.py.mako`
- added baseline migration for:
  - `cities`
  - `geocoding_cache`
  - `pipeline_runs`
  - `raw_air_pollution_responses`
  - `air_pollution_gold`
- added a dedicated Docker Compose `migrate` service to run `alembic upgrade head`
- updated docs for migration/bootstrap workflow
- added a small config test for PostgreSQL URL generation

## Why

`AIR-012.1` defined the PostgreSQL schema and persistence contract. This PR makes that schema reproducible and versioned so a fresh database can be created consistently and existing environments can be upgraded through a standard migration path.

## Validation

- passed: `./.venv/bin/pytest services/pipeline/tests/test_postgres_config.py`

## Notes

- Alembic CLI was added to the repo dependencies, but it was not installed in the current virtualenv during this work, so `alembic upgrade head` was not executed in this session.
- this PR does not yet migrate pipeline runtime behavior to the new tables
- this PR does not include dashboard PostgreSQL migration
