### PR TITLE
AIR-012.3 Refactor load layer for DB-first persistence

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,7 @@ GOLD_DIR=/app/data/gold
 
 # Optional Postgres load
 USE_POSTGRES=0
+WRITE_GOLD_PARQUET=1
 POSTGRES_HOST=postgres
 POSTGRES_PORT=5432
 POSTGRES_DB=cityair

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This repo contains a Code the Dream-friendly batch ETL project that:
 4. Writes Parquet output and can optionally publish to Postgres
 5. Serves a Streamlit dashboard over the gold dataset
 
+The migration path now supports DB-first load behavior, where PostgreSQL can be the primary load target and Parquet export is an explicit setting.
+
 ## Main run guide
 
 Use `docs/setup/run_and_debug_guide.md` for:

--- a/services/pipeline/src/pipeline/common/config.py
+++ b/services/pipeline/src/pipeline/common/config.py
@@ -15,6 +15,7 @@ class Settings(BaseSettings):
 
     # Optional Postgres load
     use_postgres: bool = False
+    write_gold_parquet: bool = True
     postgres_host: str = "postgres"
     postgres_port: int = 5432
     postgres_db: str = "cityair"

--- a/services/pipeline/src/pipeline/load/storage.py
+++ b/services/pipeline/src/pipeline/load/storage.py
@@ -1,20 +1,41 @@
 from __future__ import annotations
+from dataclasses import dataclass
 from pathlib import Path
+
 import pandas as pd
 from sqlalchemy import create_engine
 
 from ..common.config import settings
 
 
-def publish_outputs(gold_df: pd.DataFrame, gold_dir: Path, table_name: str) -> Path:
-    gold_path = gold_dir / f"{table_name}.parquet"
-    gold_df.to_parquet(gold_path, index=False)
+@dataclass(frozen=True)
+class PublishResult:
+    table_name: str | None
+    gold_path: Path | None
+    rows: int
+
+
+def _build_postgres_engine():
+    return create_engine(
+        f"postgresql+psycopg://{settings.postgres_user}:{settings.postgres_password}"
+        f"@{settings.postgres_host}:{settings.postgres_port}/{settings.postgres_db}"
+    )
+
+
+def publish_outputs(gold_df: pd.DataFrame, gold_dir: Path, table_name: str) -> PublishResult:
+    postgres_table: str | None = None
+    gold_path: Path | None = None
 
     if settings.use_postgres:
-        engine = create_engine(
-            f"postgresql+psycopg://{settings.postgres_user}:{settings.postgres_password}"
-            f"@{settings.postgres_host}:{settings.postgres_port}/{settings.postgres_db}"
-        )
+        engine = _build_postgres_engine()
         gold_df.to_sql(table_name, engine, if_exists="replace", index=False)
+        postgres_table = table_name
 
-    return gold_path
+    if settings.write_gold_parquet:
+        gold_path = gold_dir / f"{table_name}.parquet"
+        gold_df.to_parquet(gold_path, index=False)
+
+    if postgres_table is None and gold_path is None:
+        raise ValueError("At least one load target must be enabled: USE_POSTGRES=1 or WRITE_GOLD_PARQUET=1")
+
+    return PublishResult(table_name=postgres_table, gold_path=gold_path, rows=len(gold_df))

--- a/services/pipeline/src/pipeline/orchestration.py
+++ b/services/pipeline/src/pipeline/orchestration.py
@@ -11,7 +11,7 @@ from .common.logging import get_logger
 from .extract.cities import read_cities
 from .extract.geocoding import geocode_city
 from .extract.openweather_air_pollution import fetch_air_pollution_history
-from .load.storage import publish_outputs
+from .load.storage import PublishResult, publish_outputs
 from .transform.openweather_air_pollution_transform import build_gold_from_raw
 
 
@@ -24,7 +24,8 @@ class PipelineRunResult:
     source: str
     history_hours: int
     raw_files: list[Path]
-    gold_path: Path
+    gold_path: Path | None
+    postgres_table: str | None
     rows: int
 
 
@@ -72,7 +73,9 @@ def run_transform_stage(raw_files: list[Path]) -> pd.DataFrame:
     return build_gold_from_raw(raw_files=raw_files)
 
 
-def run_load_stage(gold_df: pd.DataFrame, gold_dir: Path, table_name: str = "air_pollution_gold") -> Path:
+def run_load_stage(
+    gold_df: pd.DataFrame, gold_dir: Path, table_name: str = "air_pollution_gold"
+) -> PublishResult:
     return publish_outputs(gold_df=gold_df, gold_dir=gold_dir, table_name=table_name)
 
 
@@ -86,16 +89,24 @@ def run_pipeline_job(source: str = "openweather", history_hours: int | None = No
 
     raw_files = run_extract_stage(raw_dir=raw_dir, start=start, end=end, run_id=run_id)
     gold_df = run_transform_stage(raw_files=raw_files)
-    gold_path = run_load_stage(gold_df=gold_df, gold_dir=gold_dir)
+    publish_result = run_load_stage(gold_df=gold_df, gold_dir=gold_dir)
 
     result = PipelineRunResult(
         run_id=run_id,
         source=source,
         history_hours=resolved_history_hours,
         raw_files=raw_files,
-        gold_path=gold_path,
+        gold_path=publish_result.gold_path,
+        postgres_table=publish_result.table_name,
         rows=len(gold_df),
     )
 
-    log.info("Pipeline complete", extra={"gold_path": str(result.gold_path), "rows": result.rows})
+    log.info(
+        "Pipeline complete",
+        extra={
+            "gold_path": str(result.gold_path) if result.gold_path is not None else None,
+            "postgres_table": result.postgres_table,
+            "rows": result.rows,
+        },
+    )
     return result

--- a/services/pipeline/tests/test_orchestration_runner.py
+++ b/services/pipeline/tests/test_orchestration_runner.py
@@ -5,6 +5,7 @@ import pandas as pd
 import pytest
 
 from pipeline.extract.cities import CitySpec
+from pipeline.load.storage import PublishResult
 from pipeline.orchestration import PipelineRunResult, run_pipeline_job
 import pipeline.orchestration as orchestration
 
@@ -32,7 +33,11 @@ def test_run_pipeline_job_is_importable_and_returns_result(
 
     def fake_publish_outputs(**kwargs):
         captured["publish_kwargs"] = kwargs
-        return tmp_path / "gold" / "air_pollution_gold.parquet"
+        return PublishResult(
+            table_name="air_pollution_gold",
+            gold_path=tmp_path / "gold" / "air_pollution_gold.parquet",
+            rows=1,
+        )
 
     monkeypatch.setattr(orchestration, "read_cities", fake_read_cities)
     monkeypatch.setattr(orchestration, "geocode_city", lambda **_: SimpleNamespace(lat=43.6535, lon=-79.3839))
@@ -47,6 +52,7 @@ def test_run_pipeline_job_is_importable_and_returns_result(
     assert result.history_hours == 72
     assert result.rows == 1
     assert result.gold_path == tmp_path / "gold" / "air_pollution_gold.parquet"
+    assert result.postgres_table == "air_pollution_gold"
     assert captured["cities_path"] == tmp_path / "cities.csv"
     assert captured["raw_files"] == [tmp_path / "raw" / "x.json"]
     assert isinstance(captured["publish_kwargs"]["gold_df"], pd.DataFrame)

--- a/services/pipeline/tests/test_storage_publish.py
+++ b/services/pipeline/tests/test_storage_publish.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+import pipeline.load.storage as storage
+
+
+def test_publish_outputs_supports_postgres_only(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    monkeypatch.setattr(storage.settings, "use_postgres", True)
+    monkeypatch.setattr(storage.settings, "write_gold_parquet", False)
+
+    captured: dict[str, object] = {}
+
+    class DummyEngine:
+        pass
+
+    def fake_build_postgres_engine():
+        captured["engine_built"] = True
+        return DummyEngine()
+
+    def fake_to_sql(self, name, con, if_exists, index):
+        captured["sql"] = {
+            "name": name,
+            "engine_type": type(con).__name__,
+            "if_exists": if_exists,
+            "index": index,
+        }
+
+    monkeypatch.setattr(storage, "_build_postgres_engine", fake_build_postgres_engine)
+    monkeypatch.setattr(pd.DataFrame, "to_sql", fake_to_sql, raising=False)
+
+    result = storage.publish_outputs(
+        gold_df=pd.DataFrame([{"geo_id": "Toronto,CA", "ts": "2026-04-05T00:00:00Z"}]),
+        gold_dir=tmp_path,
+        table_name="air_pollution_gold",
+    )
+
+    assert captured["engine_built"] is True
+    assert captured["sql"] == {
+        "name": "air_pollution_gold",
+        "engine_type": "DummyEngine",
+        "if_exists": "replace",
+        "index": False,
+    }
+    assert result.table_name == "air_pollution_gold"
+    assert result.gold_path is None
+    assert result.rows == 1
+
+
+def test_publish_outputs_requires_at_least_one_target(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    monkeypatch.setattr(storage.settings, "use_postgres", False)
+    monkeypatch.setattr(storage.settings, "write_gold_parquet", False)
+
+    with pytest.raises(ValueError, match=r"At least one load target must be enabled"):
+        storage.publish_outputs(
+            gold_df=pd.DataFrame([{"geo_id": "Toronto,CA", "ts": "2026-04-05T00:00:00Z"}]),
+            gold_dir=tmp_path,
+            table_name="air_pollution_gold",
+        )


### PR DESCRIPTION
## Summary

Implements `AIR-012.3` by refactoring the pipeline load stage around a DB-first persistence contract.

This PR changes the load-layer result model so PostgreSQL-backed success is first-class, makes Parquet export an explicit setting, and updates orchestration/tests so the pipeline no longer assumes a successful run is defined by a gold file path.

## What Changed

- added a structured `PublishResult` for load-stage outcomes
- changed the load layer to support PostgreSQL as the primary persistence target
- made Parquet export explicit through `WRITE_GOLD_PARQUET`
- updated orchestration to carry both:
  - `gold_path`
  - `postgres_table`
- removed the assumption that DB-backed success requires a Parquet artifact
- added tests for:
  - PostgreSQL-only publish behavior
  - invalid “no load target” behavior
  - updated orchestration result handling
- updated env/config/docs to reflect the DB-first load path

## Why

The current load stage is file-first: it writes Parquet and only optionally mirrors to PostgreSQL. That structure makes the PostgreSQL migration harder because the filesystem artifact still acts like the primary success contract.

This PR creates a DB-first load-layer structure that later PostgreSQL migration work can plug into while leaving extract and transform behavior unchanged for now.

## Validation

- passed: `.venv/bin/pytest services/pipeline/tests/test_storage_publish.py services/pipeline/tests/test_orchestration_runner.py`

## Notes

- This PR does not yet move the extract stage off raw files.
- This PR does not yet move the transform stage off raw files.
- This PR does not remove Parquet support entirely; it makes Parquet export explicit and secondary to the DB-backed load path.
- This PR does not include dashboard PostgreSQL migration.
