### PR TITLE
AIR-012.4 Add DB-backed city loading and seed import

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 OPENWEATHER_API_KEY=CHANGEME
 HISTORY_HOURS=72
 MAX_CALLS_PER_MINUTE=50
+CITIES_SOURCE=postgres
 CITIES_FILE=/app/configs/cities.csv
 
 # Container paths (Docker)

--- a/README.md
+++ b/README.md
@@ -83,7 +83,9 @@ This creates or upgrades the PostgreSQL schema before pipeline services depend o
 
 ## Configure cities
 
-The pipeline reads target cities from `CITIES_FILE`.
+The pipeline now treats PostgreSQL as the runtime source of truth for cities by default.
+
+`CITIES_FILE` remains the seed/import input used to populate the `cities` table.
 
 Expected CSV columns:
 
@@ -107,7 +109,7 @@ Notes:
 
 ### Custom city files
 
-You can point the pipeline to a different city CSV by changing `CITIES_FILE`.
+You can point the seed/import workflow to a different city CSV by changing `CITIES_FILE`.
 
 Examples:
 
@@ -123,10 +125,20 @@ For Docker Compose, custom city files must live inside `./configs/` on the host 
 
 ### Common city-file issues
 
-- `FileNotFoundError` on startup usually means `CITIES_FILE` is misspelled or points to the wrong place
+- `FileNotFoundError` during city seed/import usually means `CITIES_FILE` is misspelled or points to the wrong place
 - If Docker cannot find a custom city file, make sure the file exists under `./configs/`
-- If the pipeline produces no output, confirm the CSV has at least one data row below the header
+- If city seed/import creates no rows, confirm the CSV has at least one data row below the header
 - If geocoding fails for a city, verify the `country_code`
+
+### Seed cities into PostgreSQL
+
+To populate the `cities` table from the configured CSV:
+
+```bash
+python -m pipeline.cli --seed-cities
+```
+
+Normal pipeline execution reads active cities from PostgreSQL when `CITIES_SOURCE=postgres`.
 
 ## Additional docs
 

--- a/docs/setup/run_and_debug_guide.md
+++ b/docs/setup/run_and_debug_guide.md
@@ -118,6 +118,7 @@ Create `.env` from `.env.example`, then make it match this:
 OPENWEATHER_API_KEY=YOUR_REAL_KEY
 HISTORY_HOURS=72
 MAX_CALLS_PER_MINUTE=50
+CITIES_SOURCE=postgres
 CITIES_FILE=configs/cities.csv
 
 # Local paths (non-Docker)
@@ -147,7 +148,8 @@ DASHBOARD_DATA_PATH=./data/gold/air_pollution_gold.parquet
 
 ### Why these local values matter
 
-- `CITIES_FILE=configs/cities.csv` points the pipeline to the checked-in city list on your machine.
+- `CITIES_SOURCE=postgres` makes PostgreSQL the runtime source of truth for city selection.
+- `CITIES_FILE=configs/cities.csv` points the seed/import workflow to the checked-in city list on your machine.
 - `DATA_DIR`, `RAW_DIR`, and `GOLD_DIR` must use local paths, not `/app/...` container paths.
 - `DASHBOARD_DATA_PATH` must point to the Parquet file created by the local pipeline run.
 - `USE_POSTGRES=0` prevents the pipeline from trying to connect to a Postgres server you may not have running.
@@ -156,19 +158,25 @@ DASHBOARD_DATA_PATH=./data/gold/air_pollution_gold.parquet
 
 After your virtual environment is active and `.env` matches the values above:
 
-1. Run the pipeline:
+1. Seed cities into PostgreSQL:
+
+```bash
+python -m pipeline.cli --seed-cities
+```
+
+2. Run the pipeline:
 
 ```bash
 python services/pipeline/run_pipeline.py --source openweather --history-hours 72
 ```
 
-2. Start the dashboard:
+3. Start the dashboard:
 
 ```bash
 streamlit run services/dashboard/app/Home.py
 ```
 
-3. Open the dashboard:
+4. Open the dashboard:
 
 ```text
 http://localhost:8501

--- a/services/pipeline/src/pipeline/cli.py
+++ b/services/pipeline/src/pipeline/cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 
 from pipeline.common.config import settings
+from pipeline.extract.cities import seed_cities_from_file
 from pipeline.orchestration import run_pipeline_job
 
 
@@ -10,7 +11,13 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="City Air Tracker ETL pipeline")
     parser.add_argument("--source", default="openweather", choices=["openweather"])
     parser.add_argument("--history-hours", type=int, default=int(settings.history_hours))
+    parser.add_argument("--seed-cities", action="store_true")
     args = parser.parse_args()
+
+    if args.seed_cities:
+        seed_cities_from_file(settings.cities_file)
+        return
+
     run_pipeline_job(source=args.source, history_hours=args.history_hours)
 
 

--- a/services/pipeline/src/pipeline/common/config.py
+++ b/services/pipeline/src/pipeline/common/config.py
@@ -6,6 +6,7 @@ class Settings(BaseSettings):
     openweather_api_key: str = "7842b53c6510964cf8c2ee80d5feaab2"
     history_hours: int = 72
     max_calls_per_minute: int = 50
+    cities_source: str = "postgres"
     cities_file: str = "/app/configs/cities.csv"
 
     # Data paths

--- a/services/pipeline/src/pipeline/extract/cities.py
+++ b/services/pipeline/src/pipeline/extract/cities.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 import os
 from pathlib import Path
+
 import pandas as pd
+from sqlalchemy import create_engine, text
+
+from ..common.config import settings
 
 
 @dataclass(frozen=True)
@@ -10,6 +14,13 @@ class CitySpec:
     city: str
     country_code: str
     state: str | None = None
+
+
+@dataclass(frozen=True)
+class CitySeedResult:
+    inserted: int
+    skipped_existing: int
+    skipped_invalid: int
 
 
 def _normalize_text(value: object) -> str | None:
@@ -31,18 +42,111 @@ def _validate_cities_file(path: Path) -> None:
         raise PermissionError(f"CITIES_FILE path is not readable: {path}")
 
 
-def read_cities(path: Path) -> list[CitySpec]:
-    _validate_cities_file(path)
-    df = pd.read_csv(path)
+def _build_postgres_engine():
+    return create_engine(settings.postgres_sqlalchemy_url)
+
+
+def _parse_cities_dataframe(df: pd.DataFrame) -> tuple[list[CitySpec], int]:
     if "city" not in df.columns or "country_code" not in df.columns:
         raise ValueError("cities.csv must include columns: city,country_code,(optional)state")
 
     cities: list[CitySpec] = []
+    skipped_invalid = 0
+    seen: set[tuple[str, str, str | None]] = set()
+
     for _, r in df.iterrows():
         city = _normalize_text(r["city"])
         cc = _normalize_text(r["country_code"])
         state = _normalize_text(r["state"]) if "state" in df.columns else None
         if city is None or cc is None:
+            skipped_invalid += 1
             continue
+
+        ident = (city, cc, state)
+        if ident in seen:
+            continue
+
+        seen.add(ident)
         cities.append(CitySpec(city=city, country_code=cc, state=state))
+
+    return cities, skipped_invalid
+
+
+def read_cities_file(path: Path) -> list[CitySpec]:
+    _validate_cities_file(path)
+    df = pd.read_csv(path)
+    cities, _ = _parse_cities_dataframe(df)
     return cities
+
+
+def seed_cities_from_file(path: Path) -> CitySeedResult:
+    _validate_cities_file(path)
+    df = pd.read_csv(path)
+    cities, skipped_invalid = _parse_cities_dataframe(df)
+
+    inserted = 0
+    skipped_existing = 0
+    engine = _build_postgres_engine()
+
+    with engine.begin() as connection:
+        existing_rows = connection.execute(
+            text("SELECT city, country_code, state FROM cities")
+        ).fetchall()
+        existing = {(row[0], row[1], row[2]) for row in existing_rows}
+
+        for city in cities:
+            ident = (city.city, city.country_code, city.state)
+            if ident in existing:
+                skipped_existing += 1
+                continue
+
+            connection.execute(
+                text(
+                    """
+                    INSERT INTO cities (city, country_code, state, is_active)
+                    VALUES (:city, :country_code, :state, true)
+                    """
+                ),
+                {
+                    "city": city.city,
+                    "country_code": city.country_code,
+                    "state": city.state,
+                },
+            )
+            existing.add(ident)
+            inserted += 1
+
+    return CitySeedResult(
+        inserted=inserted,
+        skipped_existing=skipped_existing,
+        skipped_invalid=skipped_invalid,
+    )
+
+
+def read_cities_from_db() -> list[CitySpec]:
+    engine = _build_postgres_engine()
+    with engine.begin() as connection:
+        rows = connection.execute(
+            text(
+                """
+                SELECT city, country_code, state
+                FROM cities
+                WHERE is_active = true
+                ORDER BY id
+                """
+            )
+        ).fetchall()
+
+    return [CitySpec(city=row[0], country_code=row[1], state=row[2]) for row in rows]
+
+
+def read_cities(path: Path | None = None) -> list[CitySpec]:
+    if settings.cities_source == "postgres":
+        return read_cities_from_db()
+
+    if settings.cities_source == "file":
+        if path is None:
+            raise ValueError("A file path is required when CITIES_SOURCE=file")
+        return read_cities_file(path)
+
+    raise ValueError("CITIES_SOURCE must be one of: postgres,file")

--- a/services/pipeline/src/pipeline/orchestration.py
+++ b/services/pipeline/src/pipeline/orchestration.py
@@ -44,7 +44,8 @@ def build_runtime_window(history_hours: int) -> tuple[datetime, datetime]:
 
 
 def run_extract_stage(raw_dir: Path, start: datetime, end: datetime, run_id: str) -> list[Path]:
-    cities = read_cities(Path(settings.cities_file))
+    cities_path = Path(settings.cities_file) if settings.cities_source == "file" else None
+    cities = read_cities(cities_path)
     raw_files: list[Path] = []
 
     for city in cities:

--- a/services/pipeline/tests/test_cities.py
+++ b/services/pipeline/tests/test_cities.py
@@ -2,8 +2,10 @@ from pathlib import Path
 
 import pandas as pd
 import pytest
+from sqlalchemy import create_engine, text
 
-from pipeline.extract.cities import CitySpec, read_cities
+import pipeline.extract.cities as cities_module
+from pipeline.extract.cities import CitySeedResult, CitySpec, read_cities, read_cities_file, read_cities_from_db, seed_cities_from_file
 
 
 def test_read_cities_skips_blank_required_values(tmp_path: Path):
@@ -17,7 +19,7 @@ def test_read_cities_skips_blank_required_values(tmp_path: Path):
         ]
     ).to_csv(path, index=False)
 
-    cities = read_cities(path)
+    cities = read_cities_file(path)
 
     assert cities == [CitySpec(city="Toronto", country_code="CA", state="ON")]
 
@@ -32,7 +34,7 @@ def test_read_cities_skips_nan_required_values(tmp_path: Path):
         ]
     ).to_csv(path, index=False)
 
-    cities = read_cities(path)
+    cities = read_cities_file(path)
 
     assert cities == [CitySpec(city="Lagos", country_code="NG", state=None)]
 
@@ -46,13 +48,96 @@ def test_read_cities_raises_for_missing_required_columns(tmp_path: Path):
     ).to_csv(path, index=False)
 
     with pytest.raises(ValueError, match=r"cities\.csv must include columns"):
-        read_cities(path)
+        read_cities_file(path)
 
 
 def test_read_cities_raises_clear_error_for_missing_file(tmp_path: Path):
     path = tmp_path / "does-not-exist.csv"
 
     with pytest.raises(FileNotFoundError, match=r"CITIES_FILE path does not exist") as error:
-        read_cities(path)
+        read_cities_file(path)
 
     assert str(path) in str(error.value)
+
+
+def test_seed_cities_from_file_is_idempotent(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    path = tmp_path / "cities.csv"
+    pd.DataFrame(
+        [
+            {"city": "Toronto", "country_code": "CA", "state": "ON"},
+            {"city": "Toronto", "country_code": "CA", "state": "ON"},
+            {"city": "Paris", "country_code": "FR", "state": None},
+            {"city": "", "country_code": "US", "state": "CA"},
+        ]
+    ).to_csv(path, index=False)
+
+    engine = create_engine(f"sqlite+pysqlite:///{tmp_path / 'cities.db'}")
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                CREATE TABLE cities (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    city TEXT NOT NULL,
+                    country_code TEXT NOT NULL,
+                    state TEXT NULL,
+                    is_active BOOLEAN NOT NULL DEFAULT 1
+                )
+                """
+            )
+        )
+
+    monkeypatch.setattr(cities_module, "_build_postgres_engine", lambda: engine)
+
+    first = seed_cities_from_file(path)
+    second = seed_cities_from_file(path)
+
+    assert first == CitySeedResult(inserted=2, skipped_existing=0, skipped_invalid=1)
+    assert second == CitySeedResult(inserted=0, skipped_existing=2, skipped_invalid=1)
+
+
+def test_read_cities_from_db_returns_active_rows(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    engine = create_engine(f"sqlite+pysqlite:///{tmp_path / 'cities_read.db'}")
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                CREATE TABLE cities (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    city TEXT NOT NULL,
+                    country_code TEXT NOT NULL,
+                    state TEXT NULL,
+                    is_active BOOLEAN NOT NULL
+                )
+                """
+            )
+        )
+        connection.execute(
+            text(
+                """
+                INSERT INTO cities (city, country_code, state, is_active)
+                VALUES
+                    ('Toronto', 'CA', 'ON', 1),
+                    ('Paris', 'FR', NULL, 1),
+                    ('Inactive City', 'US', NULL, 0)
+                """
+            )
+        )
+
+    monkeypatch.setattr(cities_module, "_build_postgres_engine", lambda: engine)
+
+    assert read_cities_from_db() == [
+        CitySpec(city="Toronto", country_code="CA", state="ON"),
+        CitySpec(city="Paris", country_code="FR", state=None),
+    ]
+
+
+def test_read_cities_routes_to_postgres_by_default(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(cities_module.settings, "cities_source", "postgres")
+    monkeypatch.setattr(
+        cities_module,
+        "read_cities_from_db",
+        lambda: [CitySpec(city="Toronto", country_code="CA", state="ON")],
+    )
+
+    assert read_cities() == [CitySpec(city="Toronto", country_code="CA", state="ON")]

--- a/services/pipeline/tests/test_orchestration_runner.py
+++ b/services/pipeline/tests/test_orchestration_runner.py
@@ -14,12 +14,13 @@ def test_run_pipeline_job_is_importable_and_returns_result(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ):
     monkeypatch.setattr(orchestration.settings, "cities_file", str(tmp_path / "cities.csv"))
+    monkeypatch.setattr(orchestration.settings, "cities_source", "postgres")
     monkeypatch.setattr(orchestration.settings, "raw_dir", str(tmp_path / "raw"))
     monkeypatch.setattr(orchestration.settings, "gold_dir", str(tmp_path / "gold"))
 
     captured: dict[str, object] = {}
 
-    def fake_read_cities(path: Path) -> list[CitySpec]:
+    def fake_read_cities(path: Path | None) -> list[CitySpec]:
         captured["cities_path"] = path
         return [CitySpec(city="Toronto", country_code="CA", state="ON")]
 
@@ -53,7 +54,7 @@ def test_run_pipeline_job_is_importable_and_returns_result(
     assert result.rows == 1
     assert result.gold_path == tmp_path / "gold" / "air_pollution_gold.parquet"
     assert result.postgres_table == "air_pollution_gold"
-    assert captured["cities_path"] == tmp_path / "cities.csv"
+    assert captured["cities_path"] is None
     assert captured["raw_files"] == [tmp_path / "raw" / "x.json"]
     assert isinstance(captured["publish_kwargs"]["gold_df"], pd.DataFrame)
     assert captured["publish_kwargs"]["gold_dir"] == tmp_path / "gold"
@@ -66,6 +67,7 @@ def test_run_pipeline_job_fails_fast_when_cities_file_missing(
     missing_path = tmp_path / "missing-cities.csv"
 
     monkeypatch.setattr(orchestration.settings, "cities_file", str(missing_path))
+    monkeypatch.setattr(orchestration.settings, "cities_source", "file")
     monkeypatch.setattr(orchestration.settings, "raw_dir", str(tmp_path / "raw"))
     monkeypatch.setattr(orchestration.settings, "gold_dir", str(tmp_path / "gold"))
 

--- a/services/pipeline/tests/test_run_pipeline_cities_file.py
+++ b/services/pipeline/tests/test_run_pipeline_cities_file.py
@@ -9,7 +9,7 @@ def test_main_routes_cli_arguments_through_shared_runner(monkeypatch: pytest.Mon
     monkeypatch.setattr(
         pipeline_cli.argparse.ArgumentParser,
         "parse_args",
-        lambda self: Namespace(source="openweather", history_hours=72),
+        lambda self: Namespace(source="openweather", history_hours=72, seed_cities=False),
     )
 
     captured: dict[str, object] = {}
@@ -29,7 +29,7 @@ def test_main_propagates_runner_failures(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(
         pipeline_cli.argparse.ArgumentParser,
         "parse_args",
-        lambda self: Namespace(source="openweather", history_hours=72),
+        lambda self: Namespace(source="openweather", history_hours=72, seed_cities=False),
     )
 
     def fake_run_pipeline_job(*, source: str, history_hours: int):
@@ -39,3 +39,28 @@ def test_main_propagates_runner_failures(monkeypatch: pytest.MonkeyPatch):
 
     with pytest.raises(FileNotFoundError, match=r"CITIES_FILE path does not exist"):
         run_pipeline.main()
+
+
+def test_main_supports_seed_cities(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        pipeline_cli.argparse.ArgumentParser,
+        "parse_args",
+        lambda self: Namespace(source="openweather", history_hours=72, seed_cities=True),
+    )
+
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        pipeline_cli,
+        "seed_cities_from_file",
+        lambda path: captured.setdefault("cities_file", path),
+    )
+    monkeypatch.setattr(
+        pipeline_cli,
+        "run_pipeline_job",
+        lambda **kwargs: captured.setdefault("ran_pipeline", kwargs),
+    )
+
+    run_pipeline.main()
+
+    assert captured == {"cities_file": pipeline_cli.settings.cities_file}


### PR DESCRIPTION
## Summary

Implements `AIR-012.4` by moving city configuration toward PostgreSQL as the runtime source of truth.

This PR adds a CSV seed/import workflow for the `cities` table, refactors the pipeline to read cities from PostgreSQL by default, and keeps the CSV as a bootstrap artifact instead of the main runtime dependency.

## What Changed

- added `CITIES_SOURCE=postgres|file` configuration, defaulting to PostgreSQL
- refactored city-loading logic to support:
  - CSV parsing as a seed/import path
  - PostgreSQL-backed runtime city reads
- added idempotent city seed/import behavior from `configs/cities.csv`
- added CLI support for seeding cities:
  - `python -m pipeline.cli --seed-cities`
- updated orchestration so normal pipeline execution reads cities from PostgreSQL
- preserved validation behavior for invalid city rows during import
- added tests for:
  - CSV parsing behavior
  - idempotent seed/import
  - DB-backed city reads
  - CLI seed flow
  - orchestration behavior with DB-backed city loading
- updated setup/docs to explain that:
  - PostgreSQL is now the runtime source of truth for cities
  - `CITIES_FILE` is used for seed/import

## Why

The pipeline previously began from `CITIES_FILE`, which kept the extract stage dependent on a file-based input contract.

This PR makes the `cities` table the first DB-backed source-of-truth input in the ETL flow. It is the first extract-stage migration step and prepares the codebase for later work that will move geocoding cache and raw API payloads into PostgreSQL as well.

## Validation

- passed: `.venv/bin/pytest services/pipeline/tests/test_cities.py services/pipeline/tests/test_orchestration_runner.py services/pipeline/tests/test_run_pipeline_cities_file.py`

## Notes

- This PR does not yet move geocoding cache into PostgreSQL.
- This PR does not yet move raw OpenWeather responses into PostgreSQL.
- This PR does not remove the city CSV from the repo; it keeps it as the bootstrap/seed input.
- Normal runtime behavior now expects the `cities` table to be populated when `CITIES_SOURCE=postgres`.
