### PR TITLE
AIR-012.6 Move geocoding cache to PostgreSQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repo contains a Code the Dream-friendly batch ETL project that:
 5. Serves a Streamlit dashboard over the gold dataset
 
 The migration path now supports DB-first load behavior, where PostgreSQL can be the primary load target and Parquet export is an explicit setting.
+City configuration and geocoding cache are also moving into PostgreSQL as runtime state.
 
 ## Main run guide
 

--- a/docs/setup/run_and_debug_guide.md
+++ b/docs/setup/run_and_debug_guide.md
@@ -186,7 +186,7 @@ http://localhost:8501
 
 These are the expected results:
 
-- `data/raw` contains raw OpenWeather responses and manifests
+- `data/raw` contains raw OpenWeather air-pollution responses and manifests
 - `data/gold/air_pollution_gold.parquet` exists
 - the Streamlit app starts without the "Gold dataset not found" warning
 - the dashboard shows row and city metrics

--- a/services/pipeline/src/pipeline/extract/geocoding.py
+++ b/services/pipeline/src/pipeline/extract/geocoding.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 from dataclasses import dataclass
-from pathlib import Path
-import json
 from datetime import datetime, timezone
+from pathlib import Path
+
+from sqlalchemy import create_engine, text
 
 from ..common.config import settings
 from .http import RateLimiter, get_with_retries
@@ -20,18 +21,126 @@ _limiter = RateLimiter(settings.max_calls_per_minute)
 GEO_URL = "https://api.openweathermap.org/geo/1.0/direct"
 
 
-def _geo_cache_path(raw_dir: Path, city: str, country_code: str, state: str | None) -> Path:
-    safe = f"{city}_{country_code}_{state or ''}".replace(' ', '_').replace('/', '_')
-    return raw_dir / "openweather" / "geocoding" / f"{safe}.json"
+def _build_postgres_engine():
+    return create_engine(settings.postgres_sqlalchemy_url)
+
+
+def _lookup_city_id(connection, city: str, country_code: str, state: str | None) -> int:
+    row = connection.execute(
+        text(
+            """
+            SELECT id
+            FROM cities
+            WHERE city = :city
+              AND country_code = :country_code
+              AND (
+                (:state IS NULL AND state IS NULL)
+                OR state = :state
+              )
+            ORDER BY id
+            LIMIT 1
+            """
+        ),
+        {
+            "city": city,
+            "country_code": country_code,
+            "state": state,
+        },
+    ).fetchone()
+
+    if row is None:
+        raise ValueError(
+            f"City must exist in the cities table before geocoding cache can be used: "
+            f"{city},{country_code},{state or ''}"
+        )
+
+    return int(row[0])
+
+
+def _read_cached_coords(connection, city_id: int) -> Coords | None:
+    row = connection.execute(
+        text(
+            """
+            SELECT lat, lon
+            FROM geocoding_cache
+            WHERE city_id = :city_id
+            """
+        ),
+        {"city_id": city_id},
+    ).fetchone()
+
+    if row is None:
+        return None
+
+    return Coords(lat=float(row[0]), lon=float(row[1]))
+
+
+def _upsert_geocoding_cache(
+    connection,
+    *,
+    city_id: int,
+    query_text: str,
+    lat: float,
+    lon: float,
+    provider_name: str | None,
+    provider_state: str | None,
+    provider_country: str | None,
+) -> None:
+    connection.execute(
+        text(
+            """
+            INSERT INTO geocoding_cache (
+                city_id,
+                query_text,
+                lat,
+                lon,
+                provider_name,
+                provider_state,
+                provider_country,
+                fetched_at
+            )
+            VALUES (
+                :city_id,
+                :query_text,
+                :lat,
+                :lon,
+                :provider_name,
+                :provider_state,
+                :provider_country,
+                :fetched_at
+            )
+            ON CONFLICT (city_id)
+            DO UPDATE SET
+                query_text = EXCLUDED.query_text,
+                lat = EXCLUDED.lat,
+                lon = EXCLUDED.lon,
+                provider_name = EXCLUDED.provider_name,
+                provider_state = EXCLUDED.provider_state,
+                provider_country = EXCLUDED.provider_country,
+                fetched_at = EXCLUDED.fetched_at
+            """
+        ),
+        {
+            "city_id": city_id,
+            "query_text": query_text,
+            "lat": lat,
+            "lon": lon,
+            "provider_name": provider_name,
+            "provider_state": provider_state,
+            "provider_country": provider_country,
+            "fetched_at": datetime.now(timezone.utc),
+        },
+    )
 
 
 def geocode_city(raw_dir: Path, city: str, country_code: str, state: str | None = None) -> Coords:
-    out = _geo_cache_path(raw_dir, city, country_code, state)
-    out.parent.mkdir(parents=True, exist_ok=True)
+    engine = _build_postgres_engine()
 
-    if out.exists():
-        data = json.loads(out.read_text(encoding="utf-8"))
-        return Coords(lat=float(data["lat"]), lon=float(data["lon"]))
+    with engine.begin() as connection:
+        city_id = _lookup_city_id(connection, city=city, country_code=country_code, state=state)
+        cached = _read_cached_coords(connection, city_id)
+        if cached is not None:
+            return cached
 
     if not settings.openweather_api_key or settings.openweather_api_key == "CHANGEME":
         raise ValueError("OPENWEATHER_API_KEY must be set in .env")
@@ -52,12 +161,24 @@ def geocode_city(raw_dir: Path, city: str, country_code: str, state: str | None 
     best = arr[0]  # deterministic choice for POC
     payload = {
         "query": q,
-        "lat": best["lat"],
-        "lon": best["lon"],
+        "lat": float(best["lat"]),
+        "lon": float(best["lon"]),
         "name": best.get("name"),
         "state": best.get("state"),
         "country": best.get("country"),
-        "fetched_at": datetime.now(timezone.utc).isoformat(),
     }
-    out.write_text(json.dumps(payload, indent=2), encoding="utf-8")
-    return Coords(lat=float(payload["lat"]), lon=float(payload["lon"]))
+
+    with engine.begin() as connection:
+        city_id = _lookup_city_id(connection, city=city, country_code=country_code, state=state)
+        _upsert_geocoding_cache(
+            connection,
+            city_id=city_id,
+            query_text=payload["query"],
+            lat=payload["lat"],
+            lon=payload["lon"],
+            provider_name=payload["name"],
+            provider_state=payload["state"],
+            provider_country=payload["country"],
+        )
+
+    return Coords(lat=payload["lat"], lon=payload["lon"])

--- a/services/pipeline/tests/test_geocoding_cache.py
+++ b/services/pipeline/tests/test_geocoding_cache.py
@@ -1,0 +1,151 @@
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, text
+
+import pipeline.extract.geocoding as geocoding
+
+
+def _build_sqlite_engine(db_path: Path):
+    engine = create_engine(f"sqlite+pysqlite:///{db_path}")
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                CREATE TABLE cities (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    city TEXT NOT NULL,
+                    country_code TEXT NOT NULL,
+                    state TEXT NULL,
+                    is_active BOOLEAN NOT NULL DEFAULT 1
+                )
+                """
+            )
+        )
+        connection.execute(
+            text(
+                """
+                CREATE TABLE geocoding_cache (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    city_id INTEGER NOT NULL UNIQUE,
+                    query_text TEXT NOT NULL,
+                    lat NUMERIC NOT NULL,
+                    lon NUMERIC NOT NULL,
+                    provider_name TEXT NULL,
+                    provider_state TEXT NULL,
+                    provider_country TEXT NULL,
+                    fetched_at TEXT NOT NULL,
+                    created_at TEXT NULL
+                )
+                """
+            )
+        )
+    return engine
+
+
+def test_geocode_city_uses_postgres_cache_hit(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    engine = _build_sqlite_engine(tmp_path / "geo-cache-hit.db")
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                INSERT INTO cities (city, country_code, state, is_active)
+                VALUES ('Toronto', 'CA', 'ON', 1)
+                """
+            )
+        )
+        connection.execute(
+            text(
+                """
+                INSERT INTO geocoding_cache (
+                    city_id,
+                    query_text,
+                    lat,
+                    lon,
+                    provider_name,
+                    provider_state,
+                    provider_country,
+                    fetched_at
+                )
+                VALUES (1, 'Toronto,ON,CA', 43.6535, -79.3839, 'Toronto', 'Ontario', 'CA', '2026-04-05T00:00:00Z')
+                """
+            )
+        )
+
+    called = {"value": False}
+    monkeypatch.setattr(geocoding, "_build_postgres_engine", lambda: engine)
+    monkeypatch.setattr(geocoding._limiter, "wait", lambda: None)
+    monkeypatch.setattr(
+        geocoding,
+        "get_with_retries",
+        lambda *args, **kwargs: called.__setitem__("value", True),
+    )
+
+    coords = geocoding.geocode_city(
+        raw_dir=tmp_path,
+        city="Toronto",
+        country_code="CA",
+        state="ON",
+    )
+
+    assert coords == geocoding.Coords(lat=43.6535, lon=-79.3839)
+    assert called["value"] is False
+
+
+def test_geocode_city_writes_postgres_cache_on_miss(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    engine = _build_sqlite_engine(tmp_path / "geo-cache-miss.db")
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                INSERT INTO cities (city, country_code, state, is_active)
+                VALUES ('Paris', 'FR', NULL, 1)
+                """
+            )
+        )
+
+    class DummyResponse:
+        status_code = 200
+
+        def json(self):
+            return [
+                {
+                    "lat": 48.8566,
+                    "lon": 2.3522,
+                    "name": "Paris",
+                    "state": None,
+                    "country": "FR",
+                }
+            ]
+
+    monkeypatch.setattr(geocoding, "_build_postgres_engine", lambda: engine)
+    monkeypatch.setattr(geocoding._limiter, "wait", lambda: None)
+    monkeypatch.setattr(geocoding, "get_with_retries", lambda *args, **kwargs: DummyResponse())
+    monkeypatch.setattr(geocoding.settings, "openweather_api_key", "test-key")
+
+    coords = geocoding.geocode_city(
+        raw_dir=tmp_path,
+        city="Paris",
+        country_code="FR",
+        state=None,
+    )
+
+    assert coords == geocoding.Coords(lat=48.8566, lon=2.3522)
+
+    with engine.begin() as connection:
+        row = connection.execute(
+            text(
+                """
+                SELECT query_text, lat, lon, provider_name, provider_country
+                FROM geocoding_cache
+                WHERE city_id = 1
+                """
+            )
+        ).fetchone()
+
+    assert row is not None
+    assert row[0] == "Paris,FR"
+    assert float(row[1]) == 48.8566
+    assert float(row[2]) == 2.3522
+    assert row[3] == "Paris"
+    assert row[4] == "FR"


### PR DESCRIPTION
## Summary

Implements `AIR-012.6` by moving the geocoding cache from filesystem JSON files into PostgreSQL.

## What Changed

- replaced JSON geocoding-cache reads with PostgreSQL-backed cache lookup
- replaced JSON geocoding-cache writes with PostgreSQL-backed cache persistence
- preserved the current first-result geocoding behavior
- kept cache-hit behavior so repeated runs reuse coordinates without another geocoding API call
- added tests for PostgreSQL-backed cache hit and cache miss behavior
- updated docs to reflect the new cache location

## Validation

- passed: `.venv/bin/pytest services/pipeline/tests/test_geocoding_cache.py services/pipeline/tests/test_orchestration_runner.py`

## Notes

- raw OpenWeather payloads are still file-based for now
- this PR removes the geocoding-cache filesystem dependency, not all extract-stage file usage
