### PR TITLE
AIR-012.5 Persist raw extract responses in PostgreSQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repo contains a Code the Dream-friendly batch ETL project that:
 5. Serves a Streamlit dashboard over the gold dataset
 
 The migration path now supports DB-first load behavior, where PostgreSQL can be the primary load target and Parquet export is an explicit setting.
-City configuration and geocoding cache are also moving into PostgreSQL as runtime state.
+City configuration, geocoding cache, and raw extract persistence are also moving into PostgreSQL as runtime state.
 
 ## Main run guide
 

--- a/docs/setup/run_and_debug_guide.md
+++ b/docs/setup/run_and_debug_guide.md
@@ -186,7 +186,7 @@ http://localhost:8501
 
 These are the expected results:
 
-- `data/raw` contains raw OpenWeather air-pollution responses and manifests
+- PostgreSQL stores raw OpenWeather air-pollution responses and extract metadata for the DB-first migration path
 - `data/gold/air_pollution_gold.parquet` exists
 - the Streamlit app starts without the "Gold dataset not found" warning
 - the dashboard shows row and city metrics

--- a/services/pipeline/src/pipeline/extract/openweather_air_pollution.py
+++ b/services/pipeline/src/pipeline/extract/openweather_air_pollution.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
-from pathlib import Path
 import json
+from dataclasses import dataclass
 from datetime import datetime, timezone
+from pathlib import Path
+
+import sqlalchemy as sa
+from sqlalchemy import create_engine
 
 from ..common.config import settings
 from .http import RateLimiter, get_with_retries
@@ -13,8 +17,168 @@ AIR_URL = "https://api.openweathermap.org/data/2.5/air_pollution/history"
 _limiter = RateLimiter(settings.max_calls_per_minute)
 
 
+@dataclass(frozen=True)
+class RawAirPollutionRecord:
+    raw_response_id: int
+    pipeline_run_id: int
+    city_id: int
+    city: str
+    country_code: str
+    lat: float
+    lon: float
+    geo_id: str
+    request_start_utc: datetime
+    request_end_utc: datetime
+    status_code: int
+    record_count: int
+    payload_json: dict
+    fetched_at: datetime
+
+
 def _geo_id(city: str, country_code: str, lat: float, lon: float) -> str:
     return f"{city},{country_code}:{lat:.4f},{lon:.4f}".replace(' ', '_')
+
+
+metadata = sa.MetaData()
+
+cities_table = sa.Table(
+    "cities",
+    metadata,
+    sa.Column("id", sa.BigInteger()),
+    sa.Column("city", sa.Text()),
+    sa.Column("country_code", sa.Text()),
+    sa.Column("state", sa.Text()),
+)
+
+pipeline_runs_table = sa.Table(
+    "pipeline_runs",
+    metadata,
+    sa.Column("id", sa.BigInteger()),
+    sa.Column("run_id", sa.Text()),
+    sa.Column("source", sa.Text()),
+    sa.Column("history_hours", sa.Integer()),
+    sa.Column("window_start_utc", sa.DateTime(timezone=True)),
+    sa.Column("window_end_utc", sa.DateTime(timezone=True)),
+    sa.Column("status", sa.Text()),
+    sa.Column("started_at", sa.DateTime(timezone=True)),
+)
+
+raw_air_pollution_responses_table = sa.Table(
+    "raw_air_pollution_responses",
+    metadata,
+    sa.Column("id", sa.BigInteger()),
+    sa.Column("pipeline_run_id", sa.BigInteger()),
+    sa.Column("city_id", sa.BigInteger()),
+    sa.Column("geo_id", sa.Text()),
+    sa.Column("lat", sa.Numeric(9, 6)),
+    sa.Column("lon", sa.Numeric(9, 6)),
+    sa.Column("request_url", sa.Text()),
+    sa.Column("request_start_utc", sa.DateTime(timezone=True)),
+    sa.Column("request_end_utc", sa.DateTime(timezone=True)),
+    sa.Column("status_code", sa.Integer()),
+    sa.Column("record_count", sa.Integer()),
+    sa.Column("payload_json", sa.JSON()),
+    sa.Column("fetched_at", sa.DateTime(timezone=True)),
+)
+
+
+def _build_postgres_engine():
+    return create_engine(settings.postgres_sqlalchemy_url)
+
+
+def _normalize_db_datetime(value) -> datetime:
+    if isinstance(value, datetime):
+        return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+    if isinstance(value, str):
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=timezone.utc)
+    raise ValueError(f"Unsupported datetime value: {value!r}")
+
+
+def _lookup_city_id(connection, city: str, country_code: str) -> int:
+    row = connection.execute(
+        sa.select(cities_table.c.id).where(
+            cities_table.c.city == city,
+            cities_table.c.country_code == country_code,
+        )
+    ).fetchone()
+    if row is None:
+        raise ValueError(f"City must exist in the cities table before extraction: {city},{country_code}")
+    return int(row[0])
+
+
+def _ensure_pipeline_run(connection, run_id: str, start: datetime, end: datetime) -> int:
+    row = connection.execute(
+        sa.select(pipeline_runs_table.c.id).where(pipeline_runs_table.c.run_id == run_id)
+    ).fetchone()
+    if row is not None:
+        return int(row[0])
+
+    result = connection.execute(
+        pipeline_runs_table.insert().values(
+            run_id=run_id,
+            source="openweather",
+            history_hours=int((end - start).total_seconds() // 3600),
+            window_start_utc=start,
+            window_end_utc=end,
+            status="running",
+            started_at=datetime.now(timezone.utc),
+        )
+    )
+    inserted_primary_key = result.inserted_primary_key
+    inserted_id = inserted_primary_key[0] if inserted_primary_key else None
+    if inserted_id is None:
+        row = connection.execute(
+            sa.select(pipeline_runs_table.c.id).where(pipeline_runs_table.c.run_id == run_id)
+        ).fetchone()
+        if row is None:
+            raise ValueError(f"Unable to persist pipeline run metadata for run_id={run_id}")
+        return int(row[0])
+    return int(inserted_id)
+
+
+def _build_record(
+    *,
+    row,
+    city: str,
+    country_code: str,
+    payload_json: dict,
+) -> RawAirPollutionRecord:
+    return RawAirPollutionRecord(
+        raw_response_id=int(row.id),
+        pipeline_run_id=int(row.pipeline_run_id),
+        city_id=int(row.city_id),
+        city=city,
+        country_code=country_code,
+        lat=float(row.lat),
+        lon=float(row.lon),
+        geo_id=row.geo_id,
+        request_start_utc=row.request_start_utc,
+        request_end_utc=row.request_end_utc,
+        status_code=int(row.status_code),
+        record_count=int(row.record_count),
+        payload_json=payload_json,
+        fetched_at=row.fetched_at,
+    )
+
+
+def _find_existing_raw_response(connection, city_id: int, start: datetime, end: datetime):
+    rows = connection.execute(
+        sa.select(raw_air_pollution_responses_table).where(
+            raw_air_pollution_responses_table.c.city_id == city_id,
+        )
+    ).mappings().fetchall()
+
+    normalized_start = _normalize_db_datetime(start)
+    normalized_end = _normalize_db_datetime(end)
+
+    for row in rows:
+        row_start = _normalize_db_datetime(row["request_start_utc"])
+        row_end = _normalize_db_datetime(row["request_end_utc"])
+        if row_start == normalized_start and row_end == normalized_end:
+            return row
+
+    return None
 
 
 def fetch_air_pollution_history(
@@ -26,27 +190,34 @@ def fetch_air_pollution_history(
     start: datetime,
     end: datetime,
     run_id: str,
-) -> Path:
+) -> RawAirPollutionRecord:
+    del raw_dir
+
     if not settings.openweather_api_key or settings.openweather_api_key == "CHANGEME":
         raise ValueError("OPENWEATHER_API_KEY must be set in .env")
 
     geo_id = _geo_id(city, country_code, lat, lon)
-    out_dir = raw_dir / "openweather" / "air_pollution" / "history" / geo_id
-    out_dir.mkdir(parents=True, exist_ok=True)
+    engine = _build_postgres_engine()
 
-    start_ts = int(start.replace(tzinfo=timezone.utc).timestamp())
-    end_ts = int(end.replace(tzinfo=timezone.utc).timestamp())
+    with engine.begin() as connection:
+        city_id = _lookup_city_id(connection, city=city, country_code=country_code)
+        pipeline_run_id = _ensure_pipeline_run(connection, run_id=run_id, start=start, end=end)
+        existing = _find_existing_raw_response(connection, city_id=city_id, start=start, end=end)
 
-    out_path = out_dir / f"{run_id}_{start_ts}_{end_ts}.json"
-    manifest_dir = raw_dir / "openweather" / "_manifests"
-    manifest_dir.mkdir(parents=True, exist_ok=True)
-    manifest_path = manifest_dir / f"{run_id}_{geo_id}.json"
-
-    # cache hit
-    if out_path.exists():
-        return out_path
+        if existing is not None:
+            payload_json = existing["payload_json"]
+            if isinstance(payload_json, str):
+                payload_json = json.loads(payload_json)
+            return _build_record(
+                row=existing,
+                city=city,
+                country_code=country_code,
+                payload_json=payload_json,
+            )
 
     _limiter.wait()
+    start_ts = int(start.replace(tzinfo=timezone.utc).timestamp())
+    end_ts = int(end.replace(tzinfo=timezone.utc).timestamp())
     resp = get_with_retries(
         AIR_URL,
         params={
@@ -58,22 +229,44 @@ def fetch_air_pollution_history(
         },
     )
     data = resp.json()
-    out_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    fetched_at = datetime.now(timezone.utc)
 
-    manifest = {
-        "run_id": run_id,
-        "city": city,
-        "country_code": country_code,
-        "lat": lat,
-        "lon": lon,
-        "geo_id": geo_id,
-        "start_ts": start_ts,
-        "end_ts": end_ts,
-        "url": AIR_URL,
-        "status_code": resp.status_code,
-        "record_count": len(data.get("list", [])),
-        "fetched_at": datetime.now(timezone.utc).isoformat(),
-        "raw_path": str(out_path),
-    }
-    manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
-    return out_path
+    with engine.begin() as connection:
+        city_id = _lookup_city_id(connection, city=city, country_code=country_code)
+        pipeline_run_id = _ensure_pipeline_run(connection, run_id=run_id, start=start, end=end)
+        result = connection.execute(
+            raw_air_pollution_responses_table.insert().values(
+                pipeline_run_id=pipeline_run_id,
+                city_id=city_id,
+                geo_id=geo_id,
+                lat=lat,
+                lon=lon,
+                request_url=AIR_URL,
+                request_start_utc=start,
+                request_end_utc=end,
+                status_code=resp.status_code,
+                record_count=len(data.get("list", [])),
+                payload_json=data,
+                fetched_at=fetched_at,
+            )
+        )
+        inserted_primary_key = result.inserted_primary_key
+        inserted_id = inserted_primary_key[0] if inserted_primary_key else None
+        if inserted_id is None:
+            row = _find_existing_raw_response(connection, city_id=city_id, start=start, end=end)
+        else:
+            row = connection.execute(
+                sa.select(raw_air_pollution_responses_table).where(
+                    raw_air_pollution_responses_table.c.id == inserted_id
+                )
+            ).mappings().fetchone()
+
+        if row is None:
+            raise ValueError("Unable to persist raw air-pollution response in PostgreSQL")
+
+    return _build_record(
+        row=row,
+        city=city,
+        country_code=country_code,
+        payload_json=data,
+    )

--- a/services/pipeline/src/pipeline/orchestration.py
+++ b/services/pipeline/src/pipeline/orchestration.py
@@ -10,7 +10,7 @@ from .common.config import settings
 from .common.logging import get_logger
 from .extract.cities import read_cities
 from .extract.geocoding import geocode_city
-from .extract.openweather_air_pollution import fetch_air_pollution_history
+from .extract.openweather_air_pollution import RawAirPollutionRecord, fetch_air_pollution_history
 from .load.storage import PublishResult, publish_outputs
 from .transform.openweather_air_pollution_transform import build_gold_from_raw
 
@@ -23,7 +23,7 @@ class PipelineRunResult:
     run_id: str
     source: str
     history_hours: int
-    raw_files: list[Path]
+    raw_records: list[RawAirPollutionRecord]
     gold_path: Path | None
     postgres_table: str | None
     rows: int
@@ -43,10 +43,10 @@ def build_runtime_window(history_hours: int) -> tuple[datetime, datetime]:
     return start, end
 
 
-def run_extract_stage(raw_dir: Path, start: datetime, end: datetime, run_id: str) -> list[Path]:
+def run_extract_stage(raw_dir: Path, start: datetime, end: datetime, run_id: str) -> list[RawAirPollutionRecord]:
     cities_path = Path(settings.cities_file) if settings.cities_source == "file" else None
     cities = read_cities(cities_path)
-    raw_files: list[Path] = []
+    raw_records: list[RawAirPollutionRecord] = []
 
     for city in cities:
         coords = geocode_city(
@@ -55,7 +55,7 @@ def run_extract_stage(raw_dir: Path, start: datetime, end: datetime, run_id: str
             country_code=city.country_code,
             state=city.state,
         )
-        raw_path = fetch_air_pollution_history(
+        raw_record = fetch_air_pollution_history(
             raw_dir=raw_dir,
             city=city.city,
             country_code=city.country_code,
@@ -65,13 +65,13 @@ def run_extract_stage(raw_dir: Path, start: datetime, end: datetime, run_id: str
             end=end,
             run_id=run_id,
         )
-        raw_files.append(raw_path)
+        raw_records.append(raw_record)
 
-    return raw_files
+    return raw_records
 
 
-def run_transform_stage(raw_files: list[Path]) -> pd.DataFrame:
-    return build_gold_from_raw(raw_files=raw_files)
+def run_transform_stage(raw_records: list[RawAirPollutionRecord]) -> pd.DataFrame:
+    return build_gold_from_raw(raw_records=raw_records)
 
 
 def run_load_stage(
@@ -88,15 +88,15 @@ def run_pipeline_job(source: str = "openweather", history_hours: int | None = No
 
     log.info("Starting pipeline", extra={"source": source, "history_hours": resolved_history_hours})
 
-    raw_files = run_extract_stage(raw_dir=raw_dir, start=start, end=end, run_id=run_id)
-    gold_df = run_transform_stage(raw_files=raw_files)
+    raw_records = run_extract_stage(raw_dir=raw_dir, start=start, end=end, run_id=run_id)
+    gold_df = run_transform_stage(raw_records=raw_records)
     publish_result = run_load_stage(gold_df=gold_df, gold_dir=gold_dir)
 
     result = PipelineRunResult(
         run_id=run_id,
         source=source,
         history_hours=resolved_history_hours,
-        raw_files=raw_files,
+        raw_records=raw_records,
         gold_path=publish_result.gold_path,
         postgres_table=publish_result.table_name,
         rows=len(gold_df),

--- a/services/pipeline/src/pipeline/transform/openweather_air_pollution_transform.py
+++ b/services/pipeline/src/pipeline/transform/openweather_air_pollution_transform.py
@@ -1,33 +1,25 @@
 from __future__ import annotations
-from pathlib import Path
-import json
 from datetime import datetime, timezone
+
 import pandas as pd
 
+from ..extract.openweather_air_pollution import RawAirPollutionRecord
 from .risk_scoring import add_risk_score, add_aqi_category
 
 
 COMPONENT_KEYS = ["co", "no", "no2", "o3", "so2", "nh3", "pm2_5", "pm10"]
 
 
-def _infer_city_meta(path: Path) -> tuple[str, str, float, float, str]:
-    # path: .../history/<geo_id>/<file>.json
-    geo_id = path.parent.name
-    # geo_id: City,CC:lat,lon
-    head, coords = geo_id.split(":")
-    city_cc = head.split(",")
-    city = city_cc[0].replace("_", " ")
-    country_code = city_cc[1]
-    lat_s, lon_s = coords.split(",")
-    return city, country_code, float(lat_s), float(lon_s), geo_id
-
-
-def build_gold_from_raw(raw_files: list[Path]) -> pd.DataFrame:
+def build_gold_from_raw(raw_records: list[RawAirPollutionRecord]) -> pd.DataFrame:
     rows: list[dict] = []
 
-    for p in raw_files:
-        payload = json.loads(p.read_text(encoding="utf-8"))
-        city, country_code, lat, lon, geo_id = _infer_city_meta(p)
+    for raw_record in raw_records:
+        payload = raw_record.payload_json
+        city = raw_record.city
+        country_code = raw_record.country_code
+        lat = raw_record.lat
+        lon = raw_record.lon
+        geo_id = raw_record.geo_id
 
         for item in payload.get("list", []):
             ts = datetime.fromtimestamp(int(item["dt"]), tz=timezone.utc)

--- a/services/pipeline/tests/test_orchestration_runner.py
+++ b/services/pipeline/tests/test_orchestration_runner.py
@@ -5,6 +5,7 @@ import pandas as pd
 import pytest
 
 from pipeline.extract.cities import CitySpec
+from pipeline.extract.openweather_air_pollution import RawAirPollutionRecord
 from pipeline.load.storage import PublishResult
 from pipeline.orchestration import PipelineRunResult, run_pipeline_job
 import pipeline.orchestration as orchestration
@@ -26,10 +27,25 @@ def test_run_pipeline_job_is_importable_and_returns_result(
 
     def fake_fetch_air_pollution_history(**kwargs):
         captured["fetch_kwargs"] = kwargs
-        return tmp_path / "raw" / "x.json"
+        return RawAirPollutionRecord(
+            raw_response_id=1,
+            pipeline_run_id=1,
+            city_id=1,
+            city="Toronto",
+            country_code="CA",
+            lat=43.6535,
+            lon=-79.3839,
+            geo_id="Toronto,CA:43.6535,-79.3839",
+            request_start_utc=kwargs["start"],
+            request_end_utc=kwargs["end"],
+            status_code=200,
+            record_count=1,
+            payload_json={"list": []},
+            fetched_at=kwargs["end"],
+        )
 
-    def fake_build_gold_from_raw(*, raw_files: list[Path]) -> pd.DataFrame:
-        captured["raw_files"] = raw_files
+    def fake_build_gold_from_raw(*, raw_records: list[RawAirPollutionRecord]) -> pd.DataFrame:
+        captured["raw_records"] = raw_records
         return pd.DataFrame([{"geo_id": "Toronto,CA", "ts": "2026-03-17T00:00:00Z"}])
 
     def fake_publish_outputs(**kwargs):
@@ -55,7 +71,8 @@ def test_run_pipeline_job_is_importable_and_returns_result(
     assert result.gold_path == tmp_path / "gold" / "air_pollution_gold.parquet"
     assert result.postgres_table == "air_pollution_gold"
     assert captured["cities_path"] is None
-    assert captured["raw_files"] == [tmp_path / "raw" / "x.json"]
+    assert len(captured["raw_records"]) == 1
+    assert captured["raw_records"][0].city == "Toronto"
     assert isinstance(captured["publish_kwargs"]["gold_df"], pd.DataFrame)
     assert captured["publish_kwargs"]["gold_dir"] == tmp_path / "gold"
     assert captured["publish_kwargs"]["table_name"] == "air_pollution_gold"

--- a/services/pipeline/tests/test_raw_extract_postgres.py
+++ b/services/pipeline/tests/test_raw_extract_postgres.py
@@ -1,0 +1,185 @@
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy import create_engine, text
+
+import pipeline.extract.openweather_air_pollution as air_module
+
+
+def _build_sqlite_engine(db_path: Path):
+    engine = create_engine(f"sqlite+pysqlite:///{db_path}")
+    metadata = sa.MetaData()
+    sa.Table(
+        "cities",
+        metadata,
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("city", sa.Text(), nullable=False),
+        sa.Column("country_code", sa.Text(), nullable=False),
+        sa.Column("state", sa.Text(), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("1")),
+    )
+    sa.Table(
+        "pipeline_runs",
+        metadata,
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("run_id", sa.Text(), nullable=False, unique=True),
+        sa.Column("source", sa.Text(), nullable=False),
+        sa.Column("history_hours", sa.Integer(), nullable=False),
+        sa.Column("window_start_utc", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("window_end_utc", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("status", sa.Text(), nullable=False),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    sa.Table(
+        "raw_air_pollution_responses",
+        metadata,
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("pipeline_run_id", sa.Integer(), nullable=False),
+        sa.Column("city_id", sa.Integer(), nullable=False),
+        sa.Column("geo_id", sa.Text(), nullable=False),
+        sa.Column("lat", sa.Numeric(9, 6), nullable=False),
+        sa.Column("lon", sa.Numeric(9, 6), nullable=False),
+        sa.Column("request_url", sa.Text(), nullable=False),
+        sa.Column("request_start_utc", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("request_end_utc", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("status_code", sa.Integer(), nullable=False),
+        sa.Column("record_count", sa.Integer(), nullable=False),
+        sa.Column("payload_json", sa.JSON(), nullable=False),
+        sa.Column("fetched_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    metadata.create_all(engine)
+    return engine
+
+
+def test_fetch_air_pollution_history_persists_raw_response(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    engine = _build_sqlite_engine(tmp_path / "raw-extract.db")
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                INSERT INTO cities (city, country_code, state, is_active)
+                VALUES ('Toronto', 'CA', 'ON', 1)
+                """
+            )
+        )
+
+    class DummyResponse:
+        status_code = 200
+
+        def json(self):
+            return {
+                "list": [
+                    {
+                        "dt": 1735689600,
+                        "main": {"aqi": 2},
+                        "components": {"pm2_5": 10.0, "pm10": 20.0},
+                    }
+                ]
+            }
+
+    monkeypatch.setattr(air_module, "_build_postgres_engine", lambda: engine)
+    monkeypatch.setattr(air_module._limiter, "wait", lambda: None)
+    monkeypatch.setattr(air_module, "get_with_retries", lambda *args, **kwargs: DummyResponse())
+    monkeypatch.setattr(air_module.settings, "openweather_api_key", "test-key")
+
+    start = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    end = datetime(2025, 1, 2, tzinfo=timezone.utc)
+    record = air_module.fetch_air_pollution_history(
+        raw_dir=tmp_path,
+        city="Toronto",
+        country_code="CA",
+        lat=43.6535,
+        lon=-79.3839,
+        start=start,
+        end=end,
+        run_id="20250405T000000Z",
+    )
+
+    assert record.city == "Toronto"
+    assert record.country_code == "CA"
+    assert record.record_count == 1
+
+    with engine.begin() as connection:
+        run_count = connection.execute(text("SELECT COUNT(*) FROM pipeline_runs")).scalar_one()
+        raw_count = connection.execute(text("SELECT COUNT(*) FROM raw_air_pollution_responses")).scalar_one()
+
+    assert run_count == 1
+    assert raw_count == 1
+
+
+def test_fetch_air_pollution_history_reuses_existing_raw_response(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    engine = _build_sqlite_engine(tmp_path / "raw-extract-cache.db")
+    start = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    end = datetime(2025, 1, 2, tzinfo=timezone.utc)
+
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                INSERT INTO cities (id, city, country_code, state, is_active)
+                VALUES (1, 'Toronto', 'CA', 'ON', 1)
+                """
+            )
+        )
+        connection.execute(
+            text(
+                """
+                INSERT INTO pipeline_runs (
+                    id, run_id, source, history_hours, window_start_utc, window_end_utc, status, started_at
+                )
+                VALUES (
+                    1, '20250405T000000Z', 'openweather', 24, :start, :end, 'running', :start
+                )
+                """
+            ),
+            {"start": start, "end": end},
+        )
+        connection.execute(
+            text(
+                """
+                INSERT INTO raw_air_pollution_responses (
+                    id, pipeline_run_id, city_id, geo_id, lat, lon, request_url,
+                    request_start_utc, request_end_utc, status_code, record_count,
+                    payload_json, fetched_at
+                )
+                VALUES (
+                    1, 1, 1, 'Toronto,CA:43.6535,-79.3839', 43.6535, -79.3839,
+                    'https://api.openweathermap.org/data/2.5/air_pollution/history',
+                    :start, :end, 200, 1, :payload, :start
+                )
+                """
+            ),
+            {
+                "start": start,
+                "end": end,
+                "payload": '{"list":[{"dt":1735689600,"main":{"aqi":2},"components":{"pm2_5":10.0,"pm10":20.0}}]}',
+            },
+        )
+
+    called = {"value": False}
+    monkeypatch.setattr(air_module, "_build_postgres_engine", lambda: engine)
+    monkeypatch.setattr(air_module._limiter, "wait", lambda: None)
+    monkeypatch.setattr(
+        air_module,
+        "get_with_retries",
+        lambda *args, **kwargs: called.__setitem__("value", True),
+    )
+    monkeypatch.setattr(air_module.settings, "openweather_api_key", "test-key")
+
+    record = air_module.fetch_air_pollution_history(
+        raw_dir=tmp_path,
+        city="Toronto",
+        country_code="CA",
+        lat=43.6535,
+        lon=-79.3839,
+        start=start,
+        end=end,
+        run_id="20250405T000000Z",
+    )
+
+    assert record.record_count == 1
+    assert called["value"] is False

--- a/services/pipeline/tests/test_transform_basic.py
+++ b/services/pipeline/tests/test_transform_basic.py
@@ -1,13 +1,10 @@
-from pathlib import Path
-import json
 from datetime import datetime, timezone
-import pandas as pd
 
+from pipeline.extract.openweather_air_pollution import RawAirPollutionRecord
 from pipeline.transform.openweather_air_pollution_transform import build_gold_from_raw
 
 
-def test_build_gold_from_raw_parses_list(tmp_path: Path):
-    # minimal fake response
+def test_build_gold_from_raw_parses_list():
     payload = {
         "list": [
             {
@@ -17,13 +14,24 @@ def test_build_gold_from_raw_parses_list(tmp_path: Path):
             }
         ]
     }
-    # mimic expected path layout .../history/<geo_id>/<file>.json
-    geo_id = "TestCity,TC:1.0000,2.0000"
-    p = tmp_path / "openweather" / "air_pollution" / "history" / geo_id / "x.json"
-    p.parent.mkdir(parents=True, exist_ok=True)
-    p.write_text(json.dumps(payload), encoding="utf-8")
+    raw_record = RawAirPollutionRecord(
+        raw_response_id=1,
+        pipeline_run_id=1,
+        city_id=1,
+        city="TestCity",
+        country_code="TC",
+        lat=1.0,
+        lon=2.0,
+        geo_id="TestCity,TC:1.0000,2.0000",
+        request_start_utc=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        request_end_utc=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        status_code=200,
+        record_count=1,
+        payload_json=payload,
+        fetched_at=datetime(2025, 1, 1, tzinfo=timezone.utc),
+    )
 
-    df = build_gold_from_raw([p])
+    df = build_gold_from_raw([raw_record])
     assert len(df) == 1
     assert "risk_score" in df.columns
     assert df.loc[df.index[0], "aqi_category"] in {"Good","Fair","Moderate","Poor","Very Poor","Unknown"}


### PR DESCRIPTION
## Summary

Implements `AIR-012.5` by moving raw air-pollution extract persistence from JSON/manifests into PostgreSQL.

## What Changed

- replaced raw response JSON persistence with PostgreSQL-backed raw records
- replaced manifest-file metadata with PostgreSQL-backed extract metadata
- updated extract output to return raw response records instead of file paths
- updated transform and orchestration to work with DB-backed raw records
- added tests for:
  - raw response persistence
  - raw response reuse for repeated city/window requests
  - updated transform/orchestration integration
- updated docs to reflect that raw extract persistence is moving into PostgreSQL

## Validation

- passed: `.venv/bin/pytest services/pipeline/tests/test_raw_extract_postgres.py services/pipeline/tests/test_transform_basic.py services/pipeline/tests/test_orchestration_runner.py`

## Notes

- this completes the DB-backed extract persistence layer
- transform now consumes in-memory raw records, but this is not yet the full transform-to-DB refactor
- test output included SQLite datetime deprecation warnings, but the tests passed
