### PR TITLE
AIR-012.7 Add pipeline run tracking

### DIFF
--- a/services/pipeline/src/pipeline/extract/openweather_air_pollution.py
+++ b/services/pipeline/src/pipeline/extract/openweather_air_pollution.py
@@ -50,19 +50,6 @@ cities_table = sa.Table(
     sa.Column("state", sa.Text()),
 )
 
-pipeline_runs_table = sa.Table(
-    "pipeline_runs",
-    metadata,
-    sa.Column("id", sa.BigInteger()),
-    sa.Column("run_id", sa.Text()),
-    sa.Column("source", sa.Text()),
-    sa.Column("history_hours", sa.Integer()),
-    sa.Column("window_start_utc", sa.DateTime(timezone=True)),
-    sa.Column("window_end_utc", sa.DateTime(timezone=True)),
-    sa.Column("status", sa.Text()),
-    sa.Column("started_at", sa.DateTime(timezone=True)),
-)
-
 raw_air_pollution_responses_table = sa.Table(
     "raw_air_pollution_responses",
     metadata,
@@ -105,36 +92,6 @@ def _lookup_city_id(connection, city: str, country_code: str) -> int:
     if row is None:
         raise ValueError(f"City must exist in the cities table before extraction: {city},{country_code}")
     return int(row[0])
-
-
-def _ensure_pipeline_run(connection, run_id: str, start: datetime, end: datetime) -> int:
-    row = connection.execute(
-        sa.select(pipeline_runs_table.c.id).where(pipeline_runs_table.c.run_id == run_id)
-    ).fetchone()
-    if row is not None:
-        return int(row[0])
-
-    result = connection.execute(
-        pipeline_runs_table.insert().values(
-            run_id=run_id,
-            source="openweather",
-            history_hours=int((end - start).total_seconds() // 3600),
-            window_start_utc=start,
-            window_end_utc=end,
-            status="running",
-            started_at=datetime.now(timezone.utc),
-        )
-    )
-    inserted_primary_key = result.inserted_primary_key
-    inserted_id = inserted_primary_key[0] if inserted_primary_key else None
-    if inserted_id is None:
-        row = connection.execute(
-            sa.select(pipeline_runs_table.c.id).where(pipeline_runs_table.c.run_id == run_id)
-        ).fetchone()
-        if row is None:
-            raise ValueError(f"Unable to persist pipeline run metadata for run_id={run_id}")
-        return int(row[0])
-    return int(inserted_id)
 
 
 def _build_record(
@@ -190,6 +147,7 @@ def fetch_air_pollution_history(
     start: datetime,
     end: datetime,
     run_id: str,
+    pipeline_run_id: int,
 ) -> RawAirPollutionRecord:
     del raw_dir
 
@@ -201,7 +159,6 @@ def fetch_air_pollution_history(
 
     with engine.begin() as connection:
         city_id = _lookup_city_id(connection, city=city, country_code=country_code)
-        pipeline_run_id = _ensure_pipeline_run(connection, run_id=run_id, start=start, end=end)
         existing = _find_existing_raw_response(connection, city_id=city_id, start=start, end=end)
 
         if existing is not None:
@@ -233,7 +190,6 @@ def fetch_air_pollution_history(
 
     with engine.begin() as connection:
         city_id = _lookup_city_id(connection, city=city, country_code=country_code)
-        pipeline_run_id = _ensure_pipeline_run(connection, run_id=run_id, start=start, end=end)
         result = connection.execute(
             raw_air_pollution_responses_table.insert().values(
                 pipeline_run_id=pipeline_run_id,

--- a/services/pipeline/src/pipeline/orchestration.py
+++ b/services/pipeline/src/pipeline/orchestration.py
@@ -12,6 +12,7 @@ from .extract.cities import read_cities
 from .extract.geocoding import geocode_city
 from .extract.openweather_air_pollution import RawAirPollutionRecord, fetch_air_pollution_history
 from .load.storage import PublishResult, publish_outputs
+from .run_tracking import PipelineRunStatusUpdate, create_pipeline_run, update_pipeline_run_status
 from .transform.openweather_air_pollution_transform import build_gold_from_raw
 
 
@@ -20,6 +21,7 @@ log = get_logger(__name__)
 
 @dataclass(frozen=True)
 class PipelineRunResult:
+    pipeline_run_id: int
     run_id: str
     source: str
     history_hours: int
@@ -43,7 +45,9 @@ def build_runtime_window(history_hours: int) -> tuple[datetime, datetime]:
     return start, end
 
 
-def run_extract_stage(raw_dir: Path, start: datetime, end: datetime, run_id: str) -> list[RawAirPollutionRecord]:
+def run_extract_stage(
+    raw_dir: Path, start: datetime, end: datetime, run_id: str, pipeline_run_id: int
+) -> tuple[list[RawAirPollutionRecord], int]:
     cities_path = Path(settings.cities_file) if settings.cities_source == "file" else None
     cities = read_cities(cities_path)
     raw_records: list[RawAirPollutionRecord] = []
@@ -64,10 +68,11 @@ def run_extract_stage(raw_dir: Path, start: datetime, end: datetime, run_id: str
             start=start,
             end=end,
             run_id=run_id,
+            pipeline_run_id=pipeline_run_id,
         )
         raw_records.append(raw_record)
 
-    return raw_records
+    return raw_records, len(cities)
 
 
 def run_transform_stage(raw_records: list[RawAirPollutionRecord]) -> pd.DataFrame:
@@ -85,29 +90,70 @@ def run_pipeline_job(source: str = "openweather", history_hours: int | None = No
     raw_dir, gold_dir = ensure_output_directories()
     start, end = build_runtime_window(resolved_history_hours)
     run_id = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-
-    log.info("Starting pipeline", extra={"source": source, "history_hours": resolved_history_hours})
-
-    raw_records = run_extract_stage(raw_dir=raw_dir, start=start, end=end, run_id=run_id)
-    gold_df = run_transform_stage(raw_records=raw_records)
-    publish_result = run_load_stage(gold_df=gold_df, gold_dir=gold_dir)
-
-    result = PipelineRunResult(
+    pipeline_run_id = create_pipeline_run(
         run_id=run_id,
         source=source,
         history_hours=resolved_history_hours,
-        raw_records=raw_records,
-        gold_path=publish_result.gold_path,
-        postgres_table=publish_result.table_name,
-        rows=len(gold_df),
+        window_start_utc=start,
+        window_end_utc=end,
     )
 
-    log.info(
-        "Pipeline complete",
-        extra={
-            "gold_path": str(result.gold_path) if result.gold_path is not None else None,
-            "postgres_table": result.postgres_table,
-            "rows": result.rows,
-        },
-    )
-    return result
+    log.info("Starting pipeline", extra={"source": source, "history_hours": resolved_history_hours})
+    city_count = 0
+    raw_records: list[RawAirPollutionRecord] = []
+
+    try:
+        raw_records, city_count = run_extract_stage(
+            raw_dir=raw_dir,
+            start=start,
+            end=end,
+            run_id=run_id,
+            pipeline_run_id=pipeline_run_id,
+        )
+        gold_df = run_transform_stage(raw_records=raw_records)
+        publish_result = run_load_stage(gold_df=gold_df, gold_dir=gold_dir)
+
+        update_pipeline_run_status(
+            run_id,
+            PipelineRunStatusUpdate(
+                status="succeeded",
+                city_count=city_count,
+                raw_response_count=len(raw_records),
+                gold_row_count=len(gold_df),
+                finished_at=datetime.now(timezone.utc),
+            ),
+        )
+
+        result = PipelineRunResult(
+            pipeline_run_id=pipeline_run_id,
+            run_id=run_id,
+            source=source,
+            history_hours=resolved_history_hours,
+            raw_records=raw_records,
+            gold_path=publish_result.gold_path,
+            postgres_table=publish_result.table_name,
+            rows=len(gold_df),
+        )
+
+        log.info(
+            "Pipeline complete",
+            extra={
+                "pipeline_run_id": result.pipeline_run_id,
+                "gold_path": str(result.gold_path) if result.gold_path is not None else None,
+                "postgres_table": result.postgres_table,
+                "rows": result.rows,
+            },
+        )
+        return result
+    except Exception as exc:
+        update_pipeline_run_status(
+            run_id,
+            PipelineRunStatusUpdate(
+                status="failed",
+                city_count=city_count or None,
+                raw_response_count=len(raw_records) or None,
+                error_message=str(exc),
+                finished_at=datetime.now(timezone.utc),
+            ),
+        )
+        raise

--- a/services/pipeline/src/pipeline/run_tracking.py
+++ b/services/pipeline/src/pipeline/run_tracking.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+import sqlalchemy as sa
+from sqlalchemy import create_engine
+
+from .common.config import settings
+
+
+@dataclass(frozen=True)
+class PipelineRunStatusUpdate:
+    status: str
+    city_count: int | None = None
+    raw_response_count: int | None = None
+    gold_row_count: int | None = None
+    error_message: str | None = None
+    finished_at: datetime | None = None
+
+
+metadata = sa.MetaData()
+
+pipeline_runs_table = sa.Table(
+    "pipeline_runs",
+    metadata,
+    sa.Column("id", sa.BigInteger()),
+    sa.Column("run_id", sa.Text()),
+    sa.Column("source", sa.Text()),
+    sa.Column("history_hours", sa.Integer()),
+    sa.Column("window_start_utc", sa.DateTime(timezone=True)),
+    sa.Column("window_end_utc", sa.DateTime(timezone=True)),
+    sa.Column("status", sa.Text()),
+    sa.Column("city_count", sa.Integer()),
+    sa.Column("raw_response_count", sa.Integer()),
+    sa.Column("gold_row_count", sa.Integer()),
+    sa.Column("error_message", sa.Text()),
+    sa.Column("started_at", sa.DateTime(timezone=True)),
+    sa.Column("finished_at", sa.DateTime(timezone=True)),
+)
+
+
+def _build_postgres_engine():
+    return create_engine(settings.postgres_sqlalchemy_url)
+
+
+def create_pipeline_run(
+    *,
+    run_id: str,
+    source: str,
+    history_hours: int,
+    window_start_utc: datetime,
+    window_end_utc: datetime,
+) -> int:
+    engine = _build_postgres_engine()
+    with engine.begin() as connection:
+        existing = connection.execute(
+            sa.select(pipeline_runs_table.c.id).where(pipeline_runs_table.c.run_id == run_id)
+        ).fetchone()
+        if existing is not None:
+            return int(existing[0])
+
+        result = connection.execute(
+            pipeline_runs_table.insert().values(
+                run_id=run_id,
+                source=source,
+                history_hours=history_hours,
+                window_start_utc=window_start_utc,
+                window_end_utc=window_end_utc,
+                status="running",
+                started_at=datetime.now(timezone.utc),
+            )
+        )
+
+        inserted_primary_key = result.inserted_primary_key
+        inserted_id = inserted_primary_key[0] if inserted_primary_key else None
+        if inserted_id is None:
+            existing = connection.execute(
+                sa.select(pipeline_runs_table.c.id).where(pipeline_runs_table.c.run_id == run_id)
+            ).fetchone()
+            if existing is None:
+                raise ValueError(f"Unable to create pipeline run row for run_id={run_id}")
+            return int(existing[0])
+
+        return int(inserted_id)
+
+
+def update_pipeline_run_status(run_id: str, update: PipelineRunStatusUpdate) -> None:
+    engine = _build_postgres_engine()
+    values: dict[str, object] = {"status": update.status}
+
+    if update.city_count is not None:
+        values["city_count"] = update.city_count
+    if update.raw_response_count is not None:
+        values["raw_response_count"] = update.raw_response_count
+    if update.gold_row_count is not None:
+        values["gold_row_count"] = update.gold_row_count
+    if update.error_message is not None:
+        values["error_message"] = update.error_message
+    if update.finished_at is not None:
+        values["finished_at"] = update.finished_at
+
+    with engine.begin() as connection:
+        connection.execute(
+            pipeline_runs_table.update()
+            .where(pipeline_runs_table.c.run_id == run_id)
+            .values(**values)
+        )

--- a/services/pipeline/tests/test_orchestration_runner.py
+++ b/services/pipeline/tests/test_orchestration_runner.py
@@ -20,6 +20,7 @@ def test_run_pipeline_job_is_importable_and_returns_result(
     monkeypatch.setattr(orchestration.settings, "gold_dir", str(tmp_path / "gold"))
 
     captured: dict[str, object] = {}
+    status_updates: list[object] = []
 
     def fake_read_cities(path: Path | None) -> list[CitySpec]:
         captured["cities_path"] = path
@@ -61,10 +62,13 @@ def test_run_pipeline_job_is_importable_and_returns_result(
     monkeypatch.setattr(orchestration, "fetch_air_pollution_history", fake_fetch_air_pollution_history)
     monkeypatch.setattr(orchestration, "build_gold_from_raw", fake_build_gold_from_raw)
     monkeypatch.setattr(orchestration, "publish_outputs", fake_publish_outputs)
+    monkeypatch.setattr(orchestration, "create_pipeline_run", lambda **kwargs: 101)
+    monkeypatch.setattr(orchestration, "update_pipeline_run_status", lambda run_id, update: status_updates.append((run_id, update)))
 
     result = run_pipeline_job(source="openweather", history_hours=72)
 
     assert isinstance(result, PipelineRunResult)
+    assert result.pipeline_run_id == 101
     assert result.source == "openweather"
     assert result.history_hours == 72
     assert result.rows == 1
@@ -73,9 +77,16 @@ def test_run_pipeline_job_is_importable_and_returns_result(
     assert captured["cities_path"] is None
     assert len(captured["raw_records"]) == 1
     assert captured["raw_records"][0].city == "Toronto"
+    assert captured["fetch_kwargs"]["pipeline_run_id"] == 101
     assert isinstance(captured["publish_kwargs"]["gold_df"], pd.DataFrame)
     assert captured["publish_kwargs"]["gold_dir"] == tmp_path / "gold"
     assert captured["publish_kwargs"]["table_name"] == "air_pollution_gold"
+    assert len(status_updates) == 1
+    assert status_updates[0][0] == result.run_id
+    assert status_updates[0][1].status == "succeeded"
+    assert status_updates[0][1].city_count == 1
+    assert status_updates[0][1].raw_response_count == 1
+    assert status_updates[0][1].gold_row_count == 1
 
 
 def test_run_pipeline_job_fails_fast_when_cities_file_missing(
@@ -89,15 +100,21 @@ def test_run_pipeline_job_fails_fast_when_cities_file_missing(
     monkeypatch.setattr(orchestration.settings, "gold_dir", str(tmp_path / "gold"))
 
     geocode_called = {"value": False}
+    status_updates: list[object] = []
 
     def should_not_be_called(**_):
         geocode_called["value"] = True
         return SimpleNamespace(lat=0.0, lon=0.0)
 
     monkeypatch.setattr(orchestration, "geocode_city", should_not_be_called)
+    monkeypatch.setattr(orchestration, "create_pipeline_run", lambda **kwargs: 202)
+    monkeypatch.setattr(orchestration, "update_pipeline_run_status", lambda run_id, update: status_updates.append((run_id, update)))
 
     with pytest.raises(FileNotFoundError, match=r"CITIES_FILE path does not exist") as error:
         run_pipeline_job()
 
     assert str(missing_path) in str(error.value)
     assert geocode_called["value"] is False
+    assert len(status_updates) == 1
+    assert status_updates[0][1].status == "failed"
+    assert "CITIES_FILE path does not exist" in status_updates[0][1].error_message

--- a/services/pipeline/tests/test_raw_extract_postgres.py
+++ b/services/pipeline/tests/test_raw_extract_postgres.py
@@ -55,6 +55,8 @@ def _build_sqlite_engine(db_path: Path):
 
 def test_fetch_air_pollution_history_persists_raw_response(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     engine = _build_sqlite_engine(tmp_path / "raw-extract.db")
+    start = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    end = datetime(2025, 1, 2, tzinfo=timezone.utc)
     with engine.begin() as connection:
         connection.execute(
             text(
@@ -63,6 +65,19 @@ def test_fetch_air_pollution_history_persists_raw_response(monkeypatch: pytest.M
                 VALUES ('Toronto', 'CA', 'ON', 1)
                 """
             )
+        )
+        connection.execute(
+            text(
+                """
+                INSERT INTO pipeline_runs (
+                    id, run_id, source, history_hours, window_start_utc, window_end_utc, status, started_at
+                )
+                VALUES (
+                    1, '20250405T000000Z', 'openweather', 24, :start, :end, 'running', :start
+                )
+                """
+            ),
+            {"start": start, "end": end},
         )
 
     class DummyResponse:
@@ -84,8 +99,6 @@ def test_fetch_air_pollution_history_persists_raw_response(monkeypatch: pytest.M
     monkeypatch.setattr(air_module, "get_with_retries", lambda *args, **kwargs: DummyResponse())
     monkeypatch.setattr(air_module.settings, "openweather_api_key", "test-key")
 
-    start = datetime(2025, 1, 1, tzinfo=timezone.utc)
-    end = datetime(2025, 1, 2, tzinfo=timezone.utc)
     record = air_module.fetch_air_pollution_history(
         raw_dir=tmp_path,
         city="Toronto",
@@ -95,6 +108,7 @@ def test_fetch_air_pollution_history_persists_raw_response(monkeypatch: pytest.M
         start=start,
         end=end,
         run_id="20250405T000000Z",
+        pipeline_run_id=1,
     )
 
     assert record.city == "Toronto"
@@ -179,6 +193,7 @@ def test_fetch_air_pollution_history_reuses_existing_raw_response(
         start=start,
         end=end,
         run_id="20250405T000000Z",
+        pipeline_run_id=1,
     )
 
     assert record.record_count == 1

--- a/services/pipeline/tests/test_run_tracking.py
+++ b/services/pipeline/tests/test_run_tracking.py
@@ -1,0 +1,102 @@
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, text
+
+import pipeline.run_tracking as run_tracking
+
+
+def _build_sqlite_engine(db_path: Path):
+    engine = create_engine(f"sqlite+pysqlite:///{db_path}")
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                CREATE TABLE pipeline_runs (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    run_id TEXT NOT NULL UNIQUE,
+                    source TEXT NOT NULL,
+                    history_hours INTEGER NOT NULL,
+                    window_start_utc TEXT NOT NULL,
+                    window_end_utc TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    city_count INTEGER NULL,
+                    raw_response_count INTEGER NULL,
+                    gold_row_count INTEGER NULL,
+                    error_message TEXT NULL,
+                    started_at TEXT NOT NULL,
+                    finished_at TEXT NULL
+                )
+                """
+            )
+        )
+    return engine
+
+
+def test_create_pipeline_run_persists_running_row(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    engine = _build_sqlite_engine(tmp_path / "run-tracking.db")
+    monkeypatch.setattr(run_tracking, "_build_postgres_engine", lambda: engine)
+
+    run_id = "20260405T000000Z"
+    pipeline_run_id = run_tracking.create_pipeline_run(
+        run_id=run_id,
+        source="openweather",
+        history_hours=72,
+        window_start_utc=datetime(2026, 4, 5, tzinfo=timezone.utc),
+        window_end_utc=datetime(2026, 4, 8, tzinfo=timezone.utc),
+    )
+
+    assert pipeline_run_id == 1
+
+    with engine.begin() as connection:
+        row = connection.execute(
+            text("SELECT run_id, status, source, history_hours FROM pipeline_runs WHERE id = 1")
+        ).fetchone()
+
+    assert row == (run_id, "running", "openweather", 72)
+
+
+def test_update_pipeline_run_status_persists_completion_details(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    engine = _build_sqlite_engine(tmp_path / "run-tracking-update.db")
+    monkeypatch.setattr(run_tracking, "_build_postgres_engine", lambda: engine)
+
+    run_id = "20260405T000000Z"
+    run_tracking.create_pipeline_run(
+        run_id=run_id,
+        source="openweather",
+        history_hours=72,
+        window_start_utc=datetime(2026, 4, 5, tzinfo=timezone.utc),
+        window_end_utc=datetime(2026, 4, 8, tzinfo=timezone.utc),
+    )
+
+    run_tracking.update_pipeline_run_status(
+        run_id,
+        run_tracking.PipelineRunStatusUpdate(
+            status="failed",
+            city_count=4,
+            raw_response_count=2,
+            error_message="boom",
+            finished_at=datetime(2026, 4, 5, 1, tzinfo=timezone.utc),
+        ),
+    )
+
+    with engine.begin() as connection:
+        row = connection.execute(
+            text(
+                """
+                SELECT status, city_count, raw_response_count, error_message, finished_at
+                FROM pipeline_runs
+                WHERE run_id = :run_id
+                """
+            ),
+            {"run_id": run_id},
+        ).fetchone()
+
+    assert row[0] == "failed"
+    assert row[1] == 4
+    assert row[2] == 2
+    assert row[3] == "boom"
+    assert row[4] is not None


### PR DESCRIPTION
## Summary

Implements `AIR-012.7` by adding persisted pipeline run tracking in PostgreSQL.

## What Changed

- added a new run-tracking module for `pipeline_runs`
- made orchestration explicitly create a pipeline run at job start
- updated orchestration to mark runs:
  - `running` at start
  - `succeeded` on completion
  - `failed` on error
- persisted run-level metadata such as:
  - city count
  - raw response count
  - gold row count
  - failure details
- updated raw extract flow to accept a `pipeline_run_id` from orchestration
- added tests for:
  - run creation
  - status updates
  - successful orchestration run tracking
  - failed orchestration run tracking

## Validation

- passed: `.venv/bin/pytest services/pipeline/tests/test_run_tracking.py services/pipeline/tests/test_orchestration_runner.py services/pipeline/tests/test_raw_extract_postgres.py`

## Notes

- this PR adds the operational run-tracking spine for the DB-backed pipeline
- raw extract rows now attach to an explicit persisted pipeline run
- test output included SQLite datetime deprecation warnings, but the tests passed
