### PR TITLE
AIR-012.8 Refactor transform for PostgreSQL raw records

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repo contains a Code the Dream-friendly batch ETL project that:
 
 1. Geocodes global cities to lat/lon
 2. Pulls OpenWeather Air Pollution historical data
-3. Transforms raw JSON into a gold dataset
+3. Transforms PostgreSQL-backed raw response records into a gold dataset
 4. Writes Parquet output and can optionally publish to Postgres
 5. Serves a Streamlit dashboard over the gold dataset
 

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -12,21 +12,22 @@ package "City Air Tracker (Monorepo)" {
   component "Air Pollution Extractor\n(history 72h)\nopenweather_air_pollution.py" as ex
   component "Transform\nopenweather_air_pollution_transform.py" as tr
   component "Load\nstorage.py" as ld
-  database "Raw Cache\n(data/raw/openweather/...)" as raw
+  database "Postgres Raw Records\n(raw_air_pollution_responses)" as raw
   database "Gold Dataset\n(data/gold/air_pollution_gold.parquet)" as gold
-  database "Postgres (optional)" as pg
+  database "Postgres" as pg
   component "Dashboard\n(Streamlit)" as dash
-  file "cities.csv" as cities
+  database "Postgres Cities\n(cities)" as cities
 }
 
 cities --> cli
 cli --> geo
 geo --> raw : cache coords
 cli --> ex
-ex --> raw : write raw JSON + manifest
+ex --> raw : write raw responses + extract metadata
 cli --> tr
-tr --> gold : write parquet
-ld --> pg : optional
+tr --> ld : build gold DataFrame
+ld --> gold : optional parquet export
+ld --> pg : primary load target
 dash --> gold : read
 
 @enduml
@@ -42,22 +43,22 @@ participant "geocoding.py" as GEO
 participant "openweather_air_pollution.py" as EX
 participant "transform" as TR
 participant "load" as LD
-database "data/raw" as RAW
+database "Postgres raw_air_pollution_responses" as RAW
 database "data/gold" as GOLD
 database "Postgres" as PG
-file "configs/cities.csv" as CITIES
+database "Postgres cities" as CITIES
 
 User -> CLI: run --history-hours 72
-CLI -> CITIES: read list
+CLI -> CITIES: read active cities
 loop per city
   CLI -> GEO: city+country -> lat/lon
   GEO -> RAW: cache geocode result
   CLI -> EX: fetch history(lat,lon,start,end)
-  EX -> RAW: write response json + manifest
+  EX -> RAW: write or reuse raw response record
 end
-CLI -> TR: parse raw json -> tidy DF
-TR -> GOLD: write parquet
-CLI -> LD: optionally publish to DB
-LD -> PG: write table (if enabled)
+CLI -> TR: parse raw response records -> tidy DF
+CLI -> LD: publish gold dataset
+LD -> PG: write table
+LD -> GOLD: optionally write parquet
 @enduml
 ```

--- a/services/pipeline/src/pipeline/orchestration.py
+++ b/services/pipeline/src/pipeline/orchestration.py
@@ -13,7 +13,7 @@ from .extract.geocoding import geocode_city
 from .extract.openweather_air_pollution import RawAirPollutionRecord, fetch_air_pollution_history
 from .load.storage import PublishResult, publish_outputs
 from .run_tracking import PipelineRunStatusUpdate, create_pipeline_run, update_pipeline_run_status
-from .transform.openweather_air_pollution_transform import build_gold_from_raw
+from .transform.openweather_air_pollution_transform import build_gold_from_raw_records
 
 
 log = get_logger(__name__)
@@ -76,7 +76,7 @@ def run_extract_stage(
 
 
 def run_transform_stage(raw_records: list[RawAirPollutionRecord]) -> pd.DataFrame:
-    return build_gold_from_raw(raw_records=raw_records)
+    return build_gold_from_raw_records(raw_records=raw_records)
 
 
 def run_load_stage(

--- a/services/pipeline/src/pipeline/transform/openweather_air_pollution_transform.py
+++ b/services/pipeline/src/pipeline/transform/openweather_air_pollution_transform.py
@@ -10,7 +10,7 @@ from .risk_scoring import add_risk_score, add_aqi_category
 COMPONENT_KEYS = ["co", "no", "no2", "o3", "so2", "nh3", "pm2_5", "pm10"]
 
 
-def build_gold_from_raw(raw_records: list[RawAirPollutionRecord]) -> pd.DataFrame:
+def build_gold_from_raw_records(raw_records: list[RawAirPollutionRecord]) -> pd.DataFrame:
     rows: list[dict] = []
 
     for raw_record in raw_records:

--- a/services/pipeline/tests/test_orchestration_runner.py
+++ b/services/pipeline/tests/test_orchestration_runner.py
@@ -45,7 +45,7 @@ def test_run_pipeline_job_is_importable_and_returns_result(
             fetched_at=kwargs["end"],
         )
 
-    def fake_build_gold_from_raw(*, raw_records: list[RawAirPollutionRecord]) -> pd.DataFrame:
+    def fake_build_gold_from_raw_records(*, raw_records: list[RawAirPollutionRecord]) -> pd.DataFrame:
         captured["raw_records"] = raw_records
         return pd.DataFrame([{"geo_id": "Toronto,CA", "ts": "2026-03-17T00:00:00Z"}])
 
@@ -60,7 +60,7 @@ def test_run_pipeline_job_is_importable_and_returns_result(
     monkeypatch.setattr(orchestration, "read_cities", fake_read_cities)
     monkeypatch.setattr(orchestration, "geocode_city", lambda **_: SimpleNamespace(lat=43.6535, lon=-79.3839))
     monkeypatch.setattr(orchestration, "fetch_air_pollution_history", fake_fetch_air_pollution_history)
-    monkeypatch.setattr(orchestration, "build_gold_from_raw", fake_build_gold_from_raw)
+    monkeypatch.setattr(orchestration, "build_gold_from_raw_records", fake_build_gold_from_raw_records)
     monkeypatch.setattr(orchestration, "publish_outputs", fake_publish_outputs)
     monkeypatch.setattr(orchestration, "create_pipeline_run", lambda **kwargs: 101)
     monkeypatch.setattr(orchestration, "update_pipeline_run_status", lambda run_id, update: status_updates.append((run_id, update)))

--- a/services/pipeline/tests/test_transform_basic.py
+++ b/services/pipeline/tests/test_transform_basic.py
@@ -1,10 +1,10 @@
 from datetime import datetime, timezone
 
 from pipeline.extract.openweather_air_pollution import RawAirPollutionRecord
-from pipeline.transform.openweather_air_pollution_transform import build_gold_from_raw
+from pipeline.transform.openweather_air_pollution_transform import build_gold_from_raw_records
 
 
-def test_build_gold_from_raw_parses_list():
+def test_build_gold_from_raw_records_parses_list():
     payload = {
         "list": [
             {
@@ -31,7 +31,7 @@ def test_build_gold_from_raw_parses_list():
         fetched_at=datetime(2025, 1, 1, tzinfo=timezone.utc),
     )
 
-    df = build_gold_from_raw([raw_record])
+    df = build_gold_from_raw_records([raw_record])
     assert len(df) == 1
     assert "risk_score" in df.columns
     assert df.loc[df.index[0], "aqi_category"] in {"Good","Fair","Moderate","Poor","Very Poor","Unknown"}


### PR DESCRIPTION
## Summary

Implements `AIR-012.8` by making the transform stage explicitly operate on PostgreSQL-backed raw response records instead of file-based raw inputs.

## What Changed

- renamed the transform entry point to reflect the raw-record contract
- updated orchestration to call the raw-record-based transform flow
- updated tests to match the explicit PostgreSQL raw-record input
- updated docs so transform is described as DB-backed instead of file-based

## Validation

- passed: `.venv/bin/pytest services/pipeline/tests/test_transform_basic.py services/pipeline/tests/test_orchestration_runner.py services/pipeline/tests/test_raw_extract_postgres.py`

## Notes

- this formalizes behavior that had already started shifting during the raw-response persistence work
- raw extract persistence remains in PostgreSQL and now the transform contract matches that runtime model
