### PR TITLE
AIR-012.10 Make PostgreSQL the primary gold target

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,9 +10,9 @@ DATA_DIR=/app/data
 RAW_DIR=/app/data/raw
 GOLD_DIR=/app/data/gold
 
-# Optional Postgres load
-USE_POSTGRES=0
-WRITE_GOLD_PARQUET=1
+# PostgreSQL is the primary gold target
+USE_POSTGRES=1
+WRITE_GOLD_PARQUET=0
 POSTGRES_HOST=postgres
 POSTGRES_PORT=5432
 POSTGRES_DB=cityair

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ This repo contains a Code the Dream-friendly batch ETL project that:
 1. Geocodes global cities to lat/lon
 2. Pulls OpenWeather Air Pollution historical data
 3. Transforms PostgreSQL-backed raw response records into a gold dataset
-4. Writes Parquet output and can optionally publish to Postgres
+4. Writes the gold dataset to PostgreSQL and can optionally export Parquet
 5. Serves a Streamlit dashboard over the gold dataset
 
-The migration path now supports DB-first load behavior, where PostgreSQL can be the primary load target and Parquet export is an explicit setting.
+The pipeline now uses DB-first gold persistence by default, with PostgreSQL as the primary gold-data target and Parquet export as an explicit optional setting.
 City configuration, geocoding cache, and raw extract persistence are also moving into PostgreSQL as runtime state.
 
 ## Main run guide

--- a/docs/setup/postgresql_migrations_guide.md
+++ b/docs/setup/postgresql_migrations_guide.md
@@ -75,8 +75,10 @@ The expected bootstrap validation flow is:
 
 1. start PostgreSQL
 2. run `alembic upgrade head`
-3. verify the migration completes without error
-4. verify the expected tables exist
+3. seed cities with `python -m pipeline.cli --seed-cities`
+4. run the pipeline and verify `air_pollution_gold` is populated in PostgreSQL
+5. verify the migration completes without error
+6. verify the expected tables exist
 
 Example table check:
 
@@ -84,7 +86,14 @@ Example table check:
 psql postgresql://cityair:cityair@localhost:5432/cityair -c "\\dt"
 ```
 
+Example gold-row check:
+
+```bash
+psql postgresql://cityair:cityair@localhost:5432/cityair -c "select count(*) from air_pollution_gold;"
+```
+
 ## Notes
 
 - The baseline migration is the first schema version for the PostgreSQL-first MVP.
+- Normal pipeline runs now expect PostgreSQL to be the primary gold-data target.
 - Later schema changes should be added as new Alembic revision files rather than editing the baseline migration after it has been applied in shared environments.

--- a/docs/setup/run_and_debug_guide.md
+++ b/docs/setup/run_and_debug_guide.md
@@ -104,9 +104,9 @@ If you want to run this project locally without Docker, use Python plus a virtua
 
 Important:
 
-- PostgreSQL is optional on this branch.
+- PostgreSQL is the primary gold-data target on this branch.
 - The dashboard reads the Parquet file, not Postgres.
-- For runnig the application locally without Docker, the simplest supported setup is `USE_POSTGRES=0`.
+- For running the application locally without Docker, you should have PostgreSQL available and keep `USE_POSTGRES=1`.
 - The checked-in `.env.example` is Docker-oriented, so you must change it for local runs.
 
 ### Exact `.env` values for local-without-Docker
@@ -134,8 +134,9 @@ AZURE_STORAGE_CONNECTION_STRING=
 AZURE_STORAGE_ACCOUNT_NAME=
 AZURE_STORAGE_ACCOUNT_KEY=
 
-# Optional Postgres load
-USE_POSTGRES=0
+# PostgreSQL is the primary gold target
+USE_POSTGRES=1
+WRITE_GOLD_PARQUET=0
 POSTGRES_HOST=localhost
 POSTGRES_PORT=5432
 POSTGRES_DB=cityair
@@ -152,7 +153,8 @@ DASHBOARD_DATA_PATH=./data/gold/air_pollution_gold.parquet
 - `CITIES_FILE=configs/cities.csv` points the seed/import workflow to the checked-in city list on your machine.
 - `DATA_DIR`, `RAW_DIR`, and `GOLD_DIR` must use local paths, not `/app/...` container paths.
 - `DASHBOARD_DATA_PATH` must point to the Parquet file created by the local pipeline run.
-- `USE_POSTGRES=0` prevents the pipeline from trying to connect to a Postgres server you may not have running.
+- `USE_POSTGRES=1` keeps PostgreSQL as the primary gold-data target during local runs.
+- `WRITE_GOLD_PARQUET=0` keeps Parquet export disabled unless you explicitly want a secondary file artifact.
 
 ### Exact commands to run locally without Docker
 
@@ -187,7 +189,8 @@ http://localhost:8501
 These are the expected results:
 
 - PostgreSQL stores raw OpenWeather air-pollution responses and extract metadata for the DB-first migration path
-- `data/gold/air_pollution_gold.parquet` exists
+- PostgreSQL stores the gold dataset in `air_pollution_gold`
+- `data/gold/air_pollution_gold.parquet` exists only if `WRITE_GOLD_PARQUET=1`
 - the Streamlit app starts without the "Gold dataset not found" warning
 - the dashboard shows row and city metrics
 
@@ -225,7 +228,8 @@ DATA_DIR=./data
 RAW_DIR=./data/raw
 GOLD_DIR=./data/gold
 DASHBOARD_DATA_PATH=./data/gold/air_pollution_gold.parquet
-USE_POSTGRES=0
+USE_POSTGRES=1
+WRITE_GOLD_PARQUET=0
 POSTGRES_HOST=localhost
 POSTGRES_PORT=5432
 POSTGRES_DB=cityair
@@ -503,7 +507,7 @@ Healthy signs:
 
 After the pipeline finishes, these checks should pass:
 
-1. The gold data file exists at `data/gold/air_pollution_gold.parquet`.
+1. The gold data is available in PostgreSQL table `air_pollution_gold`.
 2. The raw cache exists under `data/raw`.
 3. The dashboard opens at <http://localhost:8501>.
 4. Adminer opens at <http://localhost:8080>.
@@ -516,8 +520,8 @@ docker compose exec postgres psql -U cityair -d cityair -c "\\dt"
 
 Notes:
 
-- On this branch, Postgres and Adminer start even when `USE_POSTGRES=0`.
-- The pipeline only writes to Postgres if `USE_POSTGRES=1` is set in `.env`.
+- On this branch, Postgres is part of the normal runtime path and should stay enabled.
+- Parquet export remains optional and only runs when `WRITE_GOLD_PARQUET=1`.
 
 #### Step 9: Stop the application
 

--- a/services/pipeline/src/pipeline/common/config.py
+++ b/services/pipeline/src/pipeline/common/config.py
@@ -14,9 +14,9 @@ class Settings(BaseSettings):
     raw_dir: str = "/app/data/raw"
     gold_dir: str = "/app/data/gold"
 
-    # Optional Postgres load
-    use_postgres: bool = False
-    write_gold_parquet: bool = True
+    # PostgreSQL is the primary gold target; Parquet is optional.
+    use_postgres: bool = True
+    write_gold_parquet: bool = False
     postgres_host: str = "postgres"
     postgres_port: int = 5432
     postgres_db: str = "cityair"

--- a/services/pipeline/tests/test_orchestration_runner.py
+++ b/services/pipeline/tests/test_orchestration_runner.py
@@ -53,7 +53,7 @@ def test_run_pipeline_job_is_importable_and_returns_result(
         captured["publish_kwargs"] = kwargs
         return PublishResult(
             table_name="air_pollution_gold",
-            gold_path=tmp_path / "gold" / "air_pollution_gold.parquet",
+            gold_path=None,
             rows=1,
         )
 
@@ -72,7 +72,7 @@ def test_run_pipeline_job_is_importable_and_returns_result(
     assert result.source == "openweather"
     assert result.history_hours == 72
     assert result.rows == 1
-    assert result.gold_path == tmp_path / "gold" / "air_pollution_gold.parquet"
+    assert result.gold_path is None
     assert result.postgres_table == "air_pollution_gold"
     assert captured["cities_path"] is None
     assert len(captured["raw_records"]) == 1

--- a/services/pipeline/tests/test_postgres_config.py
+++ b/services/pipeline/tests/test_postgres_config.py
@@ -1,6 +1,13 @@
 from pipeline.common.config import Settings
 
 
+def test_default_gold_target_is_postgres_first():
+    settings = Settings()
+
+    assert settings.use_postgres is True
+    assert settings.write_gold_parquet is False
+
+
 def test_postgres_sqlalchemy_url_uses_postgres_settings():
     settings = Settings(
         postgres_host="db.example",


### PR DESCRIPTION
## Summary

Implements `AIR-012.10` by making PostgreSQL the default primary gold-data target for pipeline runs.

## What Changed

- changed config defaults to `USE_POSTGRES=1` and `WRITE_GOLD_PARQUET=0`
- updated docs to describe PostgreSQL as the normal gold-data store
- updated local and Docker run guidance for DB-first gold persistence
- updated tests so the default success path no longer depends on a Parquet artifact

## Validation

- passed: `.venv/bin/pytest services/pipeline/tests/test_postgres_config.py services/pipeline/tests/test_storage_publish.py services/pipeline/tests/test_orchestration_runner.py`

## Notes

- Parquet export is still available, but only as an explicit optional artifact
- the dashboard is still Parquet-based for now; this PR changes the pipeline gold target, not the dashboard data source
