### PR TITLE
AIR-007.2 Refactor React dashboard architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repo contains a Code the Dream-friendly batch ETL project that:
 2. Pulls OpenWeather Air Pollution historical data
 3. Transforms PostgreSQL-backed raw response records into a gold dataset
 4. Writes the gold dataset to PostgreSQL and can optionally export Parquet
-5. Serves a Streamlit dashboard over the gold dataset
+5. Serves a React dashboard backed by a Python API over PostgreSQL data
 
 The pipeline now uses DB-first gold persistence by default, with PostgreSQL as the primary gold-data target and Parquet export as an explicit optional setting.
 City configuration, geocoding cache, and raw extract persistence are also moving into PostgreSQL as runtime state.

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -13,9 +13,9 @@ package "City Air Tracker (Monorepo)" {
   component "Transform\nopenweather_air_pollution_transform.py" as tr
   component "Load\nstorage.py" as ld
   database "Postgres Raw Records\n(raw_air_pollution_responses)" as raw
-  database "Gold Dataset\n(data/gold/air_pollution_gold.parquet)" as gold
+  database "Gold Dataset\n(air_pollution_gold)" as gold
   database "Postgres" as pg
-  component "Dashboard\n(Streamlit)" as dash
+  component "Dashboard API + React UI\n(server.py + frontend)" as dash
   database "Postgres Cities\n(cities)" as cities
 }
 
@@ -28,7 +28,7 @@ cli --> tr
 tr --> ld : build gold DataFrame
 ld --> gold : optional parquet export
 ld --> pg : primary load target
-dash --> gold : read
+pg --> dash : query
 
 @enduml
 ```
@@ -44,7 +44,6 @@ participant "openweather_air_pollution.py" as EX
 participant "transform" as TR
 participant "load" as LD
 database "Postgres raw_air_pollution_responses" as RAW
-database "data/gold" as GOLD
 database "Postgres" as PG
 database "Postgres cities" as CITIES
 
@@ -59,6 +58,6 @@ end
 CLI -> TR: parse raw response records -> tidy DF
 CLI -> LD: publish gold dataset
 LD -> PG: write table
-LD -> GOLD: optionally write parquet
+PG -> CLI: data available for dashboard API
 @enduml
 ```

--- a/docs/architecture/data_flow_diagram.md
+++ b/docs/architecture/data_flow_diagram.md
@@ -24,10 +24,9 @@ rectangle "Transform" {
   [openweather_air_pollution_transform.py] as TR
 }
 
-database "Gold\n(data/gold/air_pollution_gold.parquet)" as GOLD
-database "Postgres (optional)" as PG
+database "Gold\n(air_pollution_gold)" as GOLD
 rectangle "Serve" {
-  [Streamlit Dashboard] as DASH
+  [React Dashboard + Python API] as DASH
 }
 
 CITIES --> GEO
@@ -39,7 +38,6 @@ EX --> RAW
 
 RAW --> TR
 TR --> GOLD
-TR --> PG
 
 GOLD --> DASH
 @enduml

--- a/docs/collaboration/pr_review_best_practices.md
+++ b/docs/collaboration/pr_review_best_practices.md
@@ -4,7 +4,7 @@
 
 This guide helps reviewers give consistent, useful pull request feedback for the City Air Tracker repository.
 
-It is project-specific on purpose. The best PR reviews do not only check style. They confirm that a change is safe for this codebase's pipeline, Streamlit dashboard, local development workflow, and documentation.
+It is project-specific on purpose. The best PR reviews do not only check style. They confirm that a change is safe for this codebase's pipeline, React dashboard, local development workflow, and documentation.
 
 Use this guide together with the existing branch and pull request workflow materials in `docs/`.
 
@@ -81,21 +81,20 @@ Relevant areas often include:
 
 #### Dashboard changes
 
-This branch uses a Streamlit dashboard that reads the gold Parquet dataset directly.
+This branch uses a React dashboard served by `services/dashboard/server.py` and backed by PostgreSQL queries.
 
 Focus on:
 
-- whether the dashboard still reads the expected gold dataset path
+- whether the dashboard server still returns the expected payload shape
 - loading, empty, and warning states
 - whether metrics and labels still reflect the underlying dataset correctly
 - whether tables and charts still work with current gold-schema fields
-- whether dashboard pages remain usable after pipeline schema or config changes
+- whether the frontend remains usable after dashboard API or pipeline schema changes
 
 Relevant areas often include:
 
-- `services/dashboard/app/Home.py`
-- `services/dashboard/app/pages/1_City_Trends.py`
-- `services/dashboard/app/pages/2_Compare_Cities.py`
+- `services/dashboard/server.py`
+- `services/dashboard/frontend/src`
 - `services/dashboard/Dockerfile`
 - `docker-compose.yml`
 
@@ -159,9 +158,9 @@ For this project, examples of useful validation include:
 - `pytest services/pipeline/tests -q`
 - targeted test files for changed pipeline behavior
 - `python services/pipeline/run_pipeline.py --source openweather --history-hours 72`
-- `streamlit run services/dashboard/app/Home.py`
+- `python services/dashboard/server.py`
 - `docker compose up --build`
-- verifying `data/gold/air_pollution_gold.parquet` is created
+- verifying `/api/dashboard` returns the expected payload
 - verifying the dashboard renders expected metrics and tables after a pipeline run
 
 ### Maintainability
@@ -188,7 +187,7 @@ Try to make each comment easy to act on. Good review comments usually include:
 
 Examples:
 
-- "This changes the gold dataset fields used by the Streamlit pages, but I do not see the dashboard updated. Could this break `1_City_Trends.py` or `2_Compare_Cities.py`?"
+- "This changes the gold dataset fields surfaced through the dashboard API, but I do not see the React dashboard updated. Could this break the overview, trends, or compare views?"
 - "The retry path handles 429 responses, but I do not see a test for exhausted retries. Can we add one?"
 - "This adds a new environment variable. Please update the README setup section so local contributors do not miss it."
 
@@ -217,10 +216,10 @@ This reduces confusion and helps authors prioritize.
 
 ### Common risks in dashboard PRs
 
-- Streamlit pages that assume fields that no longer exist in the gold dataset
+- React views that assume fields that no longer exist in the dashboard API payload
 - pages that work with full data but fail with empty or partial data
 - misleading metric labels or sort orders
-- hard-coded paths that do not match `DASHBOARD_DATA_PATH`
+- frontend/server assumptions drifting apart
 
 ### Common risks in docs and setup PRs
 

--- a/docs/reference/data_dictionary.md
+++ b/docs/reference/data_dictionary.md
@@ -1,6 +1,6 @@
 # Data Dictionary (POC)
 
-## air_pollution_gold.parquet
+## air_pollution_gold
 
 | Column | Type | Description |
 |---|---:|---|
@@ -23,4 +23,4 @@
 | aqi_category | string | Derived category label |
 | risk_score | float | Derived score (rule-based in POC) |
 
-This schema reflects the current transform output used by the Streamlit dashboard on this branch.
+This schema reflects the current transform output served to the React dashboard through the dashboard API.

--- a/docs/setup/docker_and_compose_walkthrough.md
+++ b/docs/setup/docker_and_compose_walkthrough.md
@@ -80,42 +80,79 @@ Line-by-line explanation:
 Current file:
 
 ```dockerfile
+FROM node:20-alpine AS frontend-builder
+
+WORKDIR /frontend
+COPY services/dashboard/frontend/package.json ./package.json
+COPY services/dashboard/frontend/vite.config.js ./vite.config.js
+COPY services/dashboard/frontend/index.html ./index.html
+COPY services/dashboard/frontend/src ./src
+RUN npm install
+RUN npm run build
+
 FROM python:3.11-slim
 
 WORKDIR /app
-COPY requirements.txt /app/requirements.txt
+COPY services/dashboard/requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir -r /app/requirements.txt
 
-COPY services/dashboard /app
+COPY services/dashboard/server.py /app/server.py
+COPY --from=frontend-builder /frontend/dist /app/static
 EXPOSE 8501
-CMD ["streamlit", "run", "app/Home.py", "--server.port=8501", "--server.address=0.0.0.0"]
+CMD ["python", "server.py"]
 ```
 
 Line-by-line explanation:
 
+- `FROM node:20-alpine AS frontend-builder`
+  Starts a frontend build stage for the React dashboard assets.
+
+- `WORKDIR /frontend`
+  Sets the working directory for the frontend build.
+
+- `COPY services/dashboard/frontend/package.json ./package.json`
+  Copies the React frontend package definition.
+
+- `COPY services/dashboard/frontend/vite.config.js ./vite.config.js`
+  Copies the Vite configuration.
+
+- `COPY services/dashboard/frontend/index.html ./index.html`
+  Copies the frontend HTML entrypoint.
+
+- `COPY services/dashboard/frontend/src ./src`
+  Copies the React source files.
+
+- `RUN npm install`
+  Installs the frontend build dependencies.
+
+- `RUN npm run build`
+  Produces the static React build under `dist/`.
+
 - `FROM python:3.11-slim`
-  Uses the official Python 3.11 slim image as the starting point for the dashboard container.
+  Starts the runtime image for the dashboard server.
 
 - `WORKDIR /app`
   Sets `/app` as the working directory inside the container.
 
-- `COPY requirements.txt /app/requirements.txt`
-  Copies the shared Python dependency list into the image.
+- `COPY services/dashboard/requirements.txt /app/requirements.txt`
+  Copies the dashboard server dependencies into the image.
 
 - `RUN pip install --no-cache-dir -r /app/requirements.txt`
-  Installs the Python dependencies needed by the dashboard.
-  The dashboard uses Streamlit and related Python libraries from the same requirements file.
+  Installs the Python dependencies needed by the dashboard server.
 
-- `COPY services/dashboard /app`
-  Copies the dashboard code into the image.
+- `COPY services/dashboard/server.py /app/server.py`
+  Copies the Python dashboard server into the image.
+
+- `COPY --from=frontend-builder /frontend/dist /app/static`
+  Copies the built React frontend assets into the runtime image.
 
 - `EXPOSE 8501`
   Documents that the container listens on port `8501`.
   This does not publish the port by itself; Docker Compose does that later.
 
-- `CMD ["streamlit", "run", "app/Home.py", "--server.port=8501", "--server.address=0.0.0.0"]`
+- `CMD ["python", "server.py"]`
   Sets the default command for the dashboard container.
-  It launches the Streamlit app, tells it to use port `8501`, and binds to `0.0.0.0` so the app is reachable from outside the container.
+  It launches the Python dashboard server, which serves the React frontend and the PostgreSQL-backed dashboard API.
 
 ## `docker-compose.yml`
 
@@ -247,7 +284,8 @@ In this project, there are four services:
   Defines host mounts for the dashboard.
 
 - `- ./data:/app/data:ro`
-  Mounts the data folder read-only so the dashboard can read the generated parquet file.
+  Mounts the data folder read-only.
+  This is now mostly a compatibility mount rather than the dashboard's primary data path.
 
 - `- ./configs:/app/configs:ro`
   Mounts the config folder read-only.
@@ -266,8 +304,8 @@ In this project, there are four services:
   Starts the dashboard after the pipeline service is started.
   Note that this does not guarantee the pipeline has finished producing data; it only controls startup order.
 
-- `command: ["streamlit", "run", "app/Home.py", "--server.port=8501", "--server.address=0.0.0.0"]`
-  Starts the Streamlit dashboard inside the container.
+- `command: ["python", "server.py"]`
+  Starts the Python dashboard server, which serves the React frontend and dashboard API.
 
 ### `postgres` service
 
@@ -343,12 +381,12 @@ Docker Compose does the following:
 1. builds the pipeline and dashboard images
 2. starts Postgres
 3. starts the pipeline job
-4. starts the Streamlit dashboard
+4. starts the React dashboard server
 5. starts Adminer
 
 The important idea is that:
 
 - the pipeline writes data into `./data`
-- the dashboard reads that same data from `./data`
-- Postgres is optional for serving the same dataset in database form
+- the dashboard primarily reads PostgreSQL through its backend API
+- `./data` remains useful for optional compatibility exports
 - Adminer helps you inspect Postgres visually

--- a/docs/setup/local_postgresql_first_workflow.md
+++ b/docs/setup/local_postgresql_first_workflow.md
@@ -44,13 +44,12 @@ POSTGRES_DB=cityair
 POSTGRES_USER=cityair
 POSTGRES_PASSWORD=cityair
 
-DASHBOARD_DATA_PATH=./data/gold/air_pollution_gold.parquet
 ```
 
 Notes:
 
 - `USE_POSTGRES=1` keeps PostgreSQL as the primary gold-data target.
-- `WRITE_GOLD_PARQUET=0` disables Parquet unless you explicitly want a secondary export.
+- `WRITE_GOLD_PARQUET=0` disables Parquet unless you explicitly want a secondary export for debugging or compatibility.
 - `CITIES_SOURCE=postgres` means normal pipeline runs read cities from the database.
 - `CITIES_FILE` is still used for the seed/import step.
 
@@ -123,7 +122,7 @@ psql postgresql://cityair:cityair@localhost:5432/cityair -c "select count(*) fro
 Optional checks:
 
 - inspect `geocoding_cache` to confirm cached coordinates were stored
-- enable `WRITE_GOLD_PARQUET=1` if you want a secondary Parquet export for dashboard compatibility
+- enable `WRITE_GOLD_PARQUET=1` only if you intentionally want a secondary Parquet export
 
 ## 6. Run DB-native tests
 
@@ -152,14 +151,10 @@ For local debugging:
 - leave `WRITE_GOLD_PARQUET=0` unless you need a file artifact for dashboard debugging
 
 The current dashboard still reads Parquet, so dashboard debugging is a temporary exception to the DB-first runtime path.
-
-If you need the dashboard locally, either:
-
-- enable `WRITE_GOLD_PARQUET=1` before running the pipeline, or
-- wait until the dashboard is migrated to PostgreSQL
+The React dashboard runs from `services/dashboard/server.py` and reads PostgreSQL-backed data through `/api/dashboard`.
 
 ## Current limitations
 
 - PostgreSQL is the primary runtime store for the pipeline.
-- The Streamlit dashboard still expects a Parquet file.
-- Parquet is now a secondary compatibility artifact, not the primary gold-data contract.
+- The dashboard API and frontend depend on the dashboard server and built React assets.
+- Parquet is a secondary compatibility artifact, not the primary gold-data contract.

--- a/docs/setup/postgresql_startup_verification_cutover.md
+++ b/docs/setup/postgresql_startup_verification_cutover.md
@@ -27,7 +27,7 @@ The PostgreSQL-first pipeline should start in this order:
 3. seed cities into the `cities` table
 4. run the pipeline
 5. verify `pipeline_runs`, `raw_air_pollution_responses`, and `air_pollution_gold`
-6. enable optional Parquet export only if you need dashboard compatibility
+6. enable optional Parquet export only if you explicitly need a secondary file artifact
 
 ### Local Python startup
 
@@ -161,7 +161,7 @@ Use this sequence when moving a shared environment from earlier file-first expec
 3. seed or refresh `cities`
 4. run one validation pipeline job
 5. verify `pipeline_runs`, raw responses, and gold rows
-6. confirm any remaining Parquet dependency is intentional
+6. confirm any remaining Parquet export is intentional
 7. treat PostgreSQL as the primary runtime source of truth
 
 ### Cutover checkpoints
@@ -174,7 +174,7 @@ Before declaring cutover complete, confirm:
 - raw responses are written or reused correctly
 - gold rows are present and deduplicated
 - logs reflect DB-backed completion rather than file-backed success
-- any dashboard or downstream Parquet dependency is known and explicitly temporary
+- any remaining downstream Parquet dependency is known and explicitly temporary
 
 ## Rollback guidance
 
@@ -199,6 +199,6 @@ If a temporary compatibility rollback is necessary:
 ## Known temporary limitations
 
 - the pipeline is PostgreSQL-first
-- the Streamlit dashboard still reads Parquet
+- the dashboard is the React frontend served by `services/dashboard/server.py`
 - Parquet is a secondary compatibility artifact, not the primary gold-data contract
-- cutover is not fully complete for the user-facing app until the dashboard reads PostgreSQL directly
+- cutover still depends on the dashboard server being deployed with built frontend assets

--- a/docs/setup/run_and_debug_guide.md
+++ b/docs/setup/run_and_debug_guide.md
@@ -28,7 +28,8 @@ What they are used for on this branch:
 - `duckdb`: included as a dependency, not currently required by the main runtime path
 - `sqlalchemy`, `psycopg[binary]`: PostgreSQL connectivity
 - `alembic`: PostgreSQL schema versioning and bootstrap
-- `streamlit`, `plotly`: dashboard
+- dashboard frontend assets are built with the React/Vite app under `services/dashboard/frontend`
+- the dashboard Python server lives in `services/dashboard/server.py`
 - `pytest`: tests
 
 ## 2. How to install Python and the Python libraries
@@ -107,7 +108,7 @@ For the most direct DB-first setup and validation path, use [local_postgresql_fi
 Important:
 
 - PostgreSQL is the primary gold-data target on this branch.
-- The dashboard reads the Parquet file, not Postgres.
+- The React dashboard reads PostgreSQL-backed data through the dashboard server API.
 - For running the application locally without Docker, you should have PostgreSQL available and keep `USE_POSTGRES=1`.
 - The checked-in `.env.example` is Docker-oriented, so you must change it for local runs.
 
@@ -145,8 +146,6 @@ POSTGRES_DB=cityair
 POSTGRES_USER=cityair
 POSTGRES_PASSWORD=cityair
 
-# ---- Dashboard ----
-DASHBOARD_DATA_PATH=./data/gold/air_pollution_gold.parquet
 ```
 
 ### Why these local values matter
@@ -154,7 +153,6 @@ DASHBOARD_DATA_PATH=./data/gold/air_pollution_gold.parquet
 - `CITIES_SOURCE=postgres` makes PostgreSQL the runtime source of truth for city selection.
 - `CITIES_FILE=configs/cities.csv` points the seed/import workflow to the checked-in city list on your machine.
 - `DATA_DIR`, `RAW_DIR`, and `GOLD_DIR` must use local paths, not `/app/...` container paths.
-- `DASHBOARD_DATA_PATH` must point to the Parquet file created by the local pipeline run.
 - `USE_POSTGRES=1` keeps PostgreSQL as the primary gold-data target during local runs.
 - `WRITE_GOLD_PARQUET=0` keeps Parquet export disabled unless you explicitly want a secondary file artifact.
 
@@ -177,7 +175,7 @@ python services/pipeline/run_pipeline.py --source openweather --history-hours 72
 3. Start the dashboard:
 
 ```bash
-streamlit run services/dashboard/app/Home.py
+python services/dashboard/server.py
 ```
 
 4. Open the dashboard:
@@ -193,7 +191,7 @@ These are the expected results:
 - PostgreSQL stores raw OpenWeather air-pollution responses and extract metadata for the DB-first migration path
 - PostgreSQL stores the gold dataset in `air_pollution_gold`
 - `data/gold/air_pollution_gold.parquet` exists only if `WRITE_GOLD_PARQUET=1`
-- the Streamlit app starts without the "Gold dataset not found" warning
+- the dashboard server starts successfully on port `8501`
 - the dashboard shows row and city metrics
 
 If you only want to validate the pipeline and database behavior, you can stop after the PostgreSQL verification steps in [local_postgresql_first_workflow.md](/home/eugen/code-the-dream-workspace/practicum-city-air-tracker/docs/setup/local_postgresql_first_workflow.md) and skip the dashboard.
@@ -232,7 +230,6 @@ CITIES_FILE=configs/cities.csv
 DATA_DIR=./data
 RAW_DIR=./data/raw
 GOLD_DIR=./data/gold
-DASHBOARD_DATA_PATH=./data/gold/air_pollution_gold.parquet
 USE_POSTGRES=1
 WRITE_GOLD_PARQUET=0
 POSTGRES_HOST=localhost
@@ -282,22 +279,18 @@ Create `.vscode/launch.json` with content like this:
       }
     },
     {
-      "name": "Dashboard: Streamlit",
+      "name": "Dashboard: React server",
       "type": "debugpy",
       "request": "launch",
-      "module": "streamlit",
+      "program": "${workspaceFolder}/services/dashboard/server.py",
       "console": "integratedTerminal",
       "cwd": "${workspaceFolder}",
-      "args": [
-        "run",
-        "services/dashboard/app/Home.py",
-        "--server.port",
-        "8501",
-        "--server.address",
-        "127.0.0.1"
-      ],
       "env": {
-        "DASHBOARD_DATA_PATH": "${workspaceFolder}/data/gold/air_pollution_gold.parquet"
+        "POSTGRES_HOST": "localhost",
+        "POSTGRES_PORT": "5432",
+        "POSTGRES_DB": "cityair",
+        "POSTGRES_USER": "cityair",
+        "POSTGRES_PASSWORD": "cityair"
       }
     }
   ]
@@ -316,7 +309,7 @@ Create `.vscode/launch.json` with content like this:
    - `services/pipeline/src/pipeline/extract/openweather_air_pollution.py`
    - `services/pipeline/src/pipeline/transform/openweather_air_pollution_transform.py`
 6. Start debugging with `F5`.
-7. If you also want to debug the dashboard, enable `WRITE_GOLD_PARQUET=1`, rerun the pipeline, and then run `Dashboard: Streamlit`.
+7. If you also want to debug the dashboard, run `Dashboard: React server` after the pipeline has populated PostgreSQL.
 
 ### How to verify local debugging is working
 
@@ -328,9 +321,9 @@ For the pipeline:
 
 For the dashboard:
 
-- VS Code starts Streamlit without import errors
+- VS Code starts the dashboard server without import errors
 - <http://127.0.0.1:8501> opens successfully
-- the dashboard shows row and city counts instead of the "Gold dataset not found" warning
+- the dashboard shows row and city counts loaded from PostgreSQL
 
 ## 5. Docker Compose setup and launch
 
@@ -346,8 +339,8 @@ You do need:
 
 For this repository, Docker Compose starts these services:
 
-- `pipeline`: one-time ETL job that fetches air-quality data and writes output files
-- `dashboard`: Streamlit UI on port `8501`
+- `pipeline`: one-time ETL job that fetches air-quality data and writes PostgreSQL-backed output
+- `dashboard`: React frontend served by the Python dashboard server on port `8501`
 - `postgres`: PostgreSQL on port `5432`
 - `adminer`: Adminer UI on port `8080`
 
@@ -441,7 +434,6 @@ CITIES_FILE=/app/configs/cities.csv
 DATA_DIR=/app/data
 RAW_DIR=/app/data/raw
 GOLD_DIR=/app/data/gold
-DASHBOARD_DATA_PATH=/app/data/gold/air_pollution_gold.parquet
 ```
 
 #### Step 5: Review or edit the city list
@@ -508,7 +500,7 @@ Healthy signs:
 
 - The pipeline logs end without a traceback
 - The pipeline logs include completion output
-- The dashboard logs show Streamlit started successfully
+- The dashboard logs show the dashboard server started successfully
 
 #### Step 8: Verify outputs
 
@@ -555,7 +547,7 @@ Check:
 docker compose version
 ```
 
-#### The dashboard page says the gold dataset was not found
+#### The dashboard API returns no rows
 
 Likely causes:
 
@@ -599,7 +591,7 @@ Project files:
 - `services/dashboard/Dockerfile`
 - `services/pipeline/src/pipeline/common/config.py`
 - `services/pipeline/src/pipeline/load/storage.py`
-- `services/dashboard/app/Home.py`
+- `services/dashboard/server.py`
 
 Official external docs:
 

--- a/services/dashboard/frontend/src/App.jsx
+++ b/services/dashboard/frontend/src/App.jsx
@@ -1,35 +1,27 @@
 import { AlertTriangle, Database, RefreshCw } from "lucide-react";
-import { useMemo } from "react";
 import { DashboardShell } from "./components/DashboardShell.jsx";
 import { EmptyState, ErrorState, LoadingState } from "./components/StateCard.jsx";
-import { useDashboardData } from "./hooks/useDashboardData.js";
-import { useLocalStorageState } from "./hooks/useLocalStorageState.js";
+import { useDashboardViewModel } from "./hooks/useDashboardViewModel.js";
 import { ComparePage } from "./pages/ComparePage.jsx";
 import { CityTrendsPage } from "./pages/CityTrendsPage.jsx";
 import { OverviewPage } from "./pages/OverviewPage.jsx";
-import { PAGE_OPTIONS, STORAGE_KEYS } from "./shared/constants.js";
 
 function App() {
-  const { payload, loading, error } = useDashboardData();
-  const [activePage, setActivePage] = useLocalStorageState(STORAGE_KEYS.activePage, PAGE_OPTIONS[0].id);
-  const [metric, setMetric] = useLocalStorageState(STORAGE_KEYS.metric, "aqi");
-  const [selectedGeoId, setSelectedGeoId] = useLocalStorageState(STORAGE_KEYS.selectedGeoId, "");
-
-  const latestByCity = payload?.latestByCity ?? [];
-  const rows = payload?.rows ?? [];
-
-  const selectedCity = useMemo(() => {
-    if (!latestByCity.length) {
-      return null;
-    }
-
-    return latestByCity.find((row) => row.geo_id === selectedGeoId) ?? latestByCity[0];
-  }, [latestByCity, selectedGeoId]);
-
-  const cityRows = useMemo(
-    () => rows.filter((row) => row.geo_id === selectedCity?.geo_id),
-    [rows, selectedCity],
-  );
+  const {
+    payload,
+    loading,
+    error,
+    reload,
+    activePage,
+    setActivePage,
+    metric,
+    setMetric,
+    selectedGeoId,
+    setSelectedGeoId,
+    selectedCity,
+    latestByCity,
+    cityRows,
+  } = useDashboardViewModel();
 
   if (loading) {
     return (
@@ -42,7 +34,15 @@ function App() {
   }
 
   if (error) {
-    return <ErrorState icon={AlertTriangle} title="The dashboard could not load" description={error} />;
+    return (
+      <ErrorState
+        icon={AlertTriangle}
+        title="The dashboard could not load"
+        description={error}
+        actionLabel="Try Again"
+        onAction={reload}
+      />
+    );
   }
 
   if (!payload || !latestByCity.length || !selectedCity) {

--- a/services/dashboard/frontend/src/components/StateCard.jsx
+++ b/services/dashboard/frontend/src/components/StateCard.jsx
@@ -1,10 +1,23 @@
-export function StateCard({ className = "", icon: Icon, title, description, spinning = false }) {
+export function StateCard({
+  className = "",
+  icon: Icon,
+  title,
+  description,
+  spinning = false,
+  actionLabel,
+  onAction,
+}) {
   return (
     <div className="shell shell--centered">
       <div className={`state-card ${className}`.trim()}>
         <Icon className={spinning ? "spin" : ""} size={28} />
         <h1>{title}</h1>
         <p>{description}</p>
+        {actionLabel && onAction ? (
+          <button className="button button--primary" type="button" onClick={onAction}>
+            {actionLabel}
+          </button>
+        ) : null}
       </div>
     </div>
   );

--- a/services/dashboard/frontend/src/hooks/useDashboardData.js
+++ b/services/dashboard/frontend/src/hooks/useDashboardData.js
@@ -1,44 +1,54 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 export function useDashboardData() {
   const [payload, setPayload] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
+  const activeControllerRef = useRef(null);
 
-  useEffect(() => {
-    let cancelled = false;
+  const loadData = useCallback(async () => {
+    activeControllerRef.current?.abort();
+    const controller = new AbortController();
+    activeControllerRef.current = controller;
 
-    async function loadData() {
-      try {
-        setLoading(true);
-        setError("");
+    try {
+      setLoading(true);
+      setError("");
 
-        const response = await fetch("/api/dashboard");
-        if (!response.ok) {
-          throw new Error(`Dashboard API returned ${response.status}`);
-        }
+      const response = await fetch("/api/dashboard", { signal: controller.signal });
+      if (!response.ok) {
+        throw new Error(`Dashboard API returned ${response.status}`);
+      }
 
-        const data = await response.json();
-        if (!cancelled) {
-          setPayload(data);
-        }
-      } catch (loadError) {
-        if (!cancelled) {
-          setError(loadError instanceof Error ? loadError.message : "Unknown dashboard error");
-        }
-      } finally {
-        if (!cancelled) {
-          setLoading(false);
-        }
+      const data = await response.json();
+      if (!controller.signal.aborted) {
+        setPayload(data);
+      }
+    } catch (loadError) {
+      if (loadError instanceof DOMException && loadError.name === "AbortError") {
+        return;
+      }
+
+      if (!controller.signal.aborted) {
+        setError(loadError instanceof Error ? loadError.message : "Unknown dashboard error");
+      }
+    } finally {
+      if (!controller.signal.aborted) {
+        setLoading(false);
+      }
+      if (activeControllerRef.current === controller) {
+        activeControllerRef.current = null;
       }
     }
+  }, []);
 
+  useEffect(() => {
     loadData();
 
     return () => {
-      cancelled = true;
+      activeControllerRef.current?.abort();
     };
-  }, []);
+  }, [loadData]);
 
-  return { payload, loading, error };
+  return { payload, loading, error, reload: loadData };
 }

--- a/services/dashboard/frontend/src/hooks/useDashboardViewModel.js
+++ b/services/dashboard/frontend/src/hooks/useDashboardViewModel.js
@@ -1,0 +1,43 @@
+import { useMemo } from "react";
+import { useDashboardData } from "./useDashboardData.js";
+import { useLocalStorageState } from "./useLocalStorageState.js";
+import { PAGE_OPTIONS, STORAGE_KEYS } from "../shared/constants.js";
+
+export function useDashboardViewModel() {
+  const { payload, loading, error, reload } = useDashboardData();
+  const [activePage, setActivePage] = useLocalStorageState(STORAGE_KEYS.activePage, PAGE_OPTIONS[0].id);
+  const [metric, setMetric] = useLocalStorageState(STORAGE_KEYS.metric, "aqi");
+  const [selectedGeoId, setSelectedGeoId] = useLocalStorageState(STORAGE_KEYS.selectedGeoId, "");
+
+  const latestByCity = payload?.latestByCity ?? [];
+  const rows = payload?.rows ?? [];
+
+  const selectedCity = useMemo(() => {
+    if (!latestByCity.length) {
+      return null;
+    }
+
+    return latestByCity.find((row) => row.geo_id === selectedGeoId) ?? latestByCity[0];
+  }, [latestByCity, selectedGeoId]);
+
+  const cityRows = useMemo(
+    () => rows.filter((row) => row.geo_id === selectedCity?.geo_id),
+    [rows, selectedCity],
+  );
+
+  return {
+    payload,
+    loading,
+    error,
+    reload,
+    activePage,
+    setActivePage,
+    metric,
+    setMetric,
+    selectedGeoId,
+    setSelectedGeoId,
+    selectedCity,
+    latestByCity,
+    cityRows,
+  };
+}

--- a/services/dashboard/frontend/src/styles.css
+++ b/services/dashboard/frontend/src/styles.css
@@ -439,6 +439,20 @@ input:focus-visible {
   width: 100%;
 }
 
+.button {
+  border: 0;
+  border-radius: 16px;
+  padding: 11px 16px;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.button--primary {
+  background: linear-gradient(135deg, #6aa7ff, #79d4ff);
+  color: #ffffff;
+  box-shadow: 0 12px 24px rgba(92, 163, 255, 0.28);
+}
+
 .table-wrap {
   overflow: auto;
 }
@@ -502,6 +516,10 @@ input:focus-visible {
   max-width: 520px;
   padding: 28px;
   text-align: center;
+}
+
+.state-card .button {
+  margin-top: 16px;
 }
 
 .state-card--error {


### PR DESCRIPTION
## Summary

Implements `AIR-007.2` by tightening the React dashboard architecture and updating docs to reflect the React/PostgreSQL dashboard path.

## What Changed

- added `useDashboardViewModel()` to centralize dashboard page/view state
- improved `useDashboardData()` with reload, retry, and abort handling
- simplified `App.jsx` to render from the new view-model hook
- added retry support to the dashboard error state
- updated docs to describe the React dashboard and Python dashboard server instead of the old Streamlit path

## Validation

- passed: `env PYTHONPATH=. pytest services/dashboard/tests/test_server.py`

