### PR TITLE
AIR-009.1 Add Azure Blob publishing with Azurite support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,12 +13,21 @@ GOLD_DIR=/app/data/gold
 # PostgreSQL is the primary gold target
 USE_POSTGRES=1
 WRITE_GOLD_PARQUET=0
+WRITE_GOLD_AZURE_BLOB=0
 POSTGRES_HOST=postgres
 POSTGRES_PORT=5432
 POSTGRES_DB=cityair
 POSTGRES_USER=cityair
 POSTGRES_PASSWORD=cityair
 ALEMBIC_DATABASE_URL=
+
+# Azure Blob publishing
+# This connection string uses the Docker Compose service name `azurite`.
+# Host-based tools such as local browsers or desktop storage explorers should use
+# `localhost` instead of `azurite` in the BlobEndpoint.
+AZURE_STORAGE_CONNECTION_STRING=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1;
+AZURE_BLOB_CONTAINER=gold
+AZURE_BLOB_PATH=exports/{table_name}.parquet
 
 # ---- Dashboard ----
 DASHBOARD_DATA_PATH=/app/data/gold/air_pollution_gold.parquet

--- a/README.md
+++ b/README.md
@@ -5,10 +5,11 @@ This repo contains a Code the Dream-friendly batch ETL project that:
 1. Geocodes global cities to lat/lon
 2. Pulls OpenWeather Air Pollution historical data
 3. Transforms PostgreSQL-backed raw response records into a gold dataset
-4. Writes the gold dataset to PostgreSQL and can optionally export Parquet
+4. Writes the gold dataset to PostgreSQL and can optionally export Parquet locally or publish the same Parquet artifact to Azure Blob Storage
 5. Serves a React dashboard backed by a Python API over PostgreSQL data
 
 The pipeline now uses DB-first gold persistence by default, with PostgreSQL as the primary gold-data target and Parquet export as an explicit optional setting.
+Azure Blob publishing is also optional and can be tested locally through Azurite in Docker Compose.
 City configuration, geocoding cache, and raw extract persistence are also moving into PostgreSQL as runtime state.
 
 ## Main run guide
@@ -84,6 +85,14 @@ Quick sequence:
 2. `python -m pipeline.cli --seed-cities`
 3. `python -m pipeline.cli --source openweather --history-hours 72`
 4. verify `pipeline_runs` and `air_pollution_gold` in PostgreSQL
+
+Optional Blob flow for local testing:
+
+1. set `WRITE_GOLD_AZURE_BLOB=1`
+2. keep the Azurite connection string from `.env.example`
+3. run `docker compose up --build`
+4. open the browser explorer at `http://localhost:8081`
+5. confirm the blob exists under container `gold` at `exports/air_pollution_gold.parquet`
 
 ## PostgreSQL schema bootstrap
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,8 @@ services:
       dockerfile: services/pipeline/Dockerfile
     env_file: .env
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
     command: ["alembic", "upgrade", "head"]
     restart: "no"
 
@@ -18,8 +19,12 @@ services:
       - ./data:/app/data
       - ./configs:/app/configs:ro
     depends_on:
-      - postgres
-      - migrate
+      postgres:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+      azurite:
+        condition: service_started
     command: ["python", "-m", "pipeline.cli", "--source", "openweather", "--history-hours", "72"]
     restart: "no"
 
@@ -40,7 +45,8 @@ services:
     ports:
       - "8501:8501"
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
 
   postgres:
     image: postgres:16
@@ -52,13 +58,50 @@ services:
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U cityair -d cityair"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 5s
 
   adminer:
     image: adminer:4
     ports:
       - "8080:8080"
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
+
+  azurite:
+    image: mcr.microsoft.com/azure-storage/azurite
+    command:
+      [
+        "azurite-blob",
+        "--blobHost",
+        "0.0.0.0",
+        "--blobPort",
+        "10000",
+        "--location",
+        "/data",
+        "--skipApiVersionCheck",
+      ]
+    ports:
+      - "10000:10000"
+    volumes:
+      - azurite_data:/data
+
+  azurestorageexplorer:
+    image: sebagomez/azurestorageexplorer:3.1.0
+    ports:
+      - "8081:8080"
+    environment:
+      AZURITE: "true"
+      AZURE_STORAGE_CONNECTIONSTRING: ${AZURE_STORAGE_CONNECTION_STRING}
+    depends_on:
+      azurite:
+        condition: service_started
 
 volumes:
   postgres_data:
+  azurite_data:

--- a/docs/setup/docker_and_compose_walkthrough.md
+++ b/docs/setup/docker_and_compose_walkthrough.md
@@ -10,6 +10,8 @@ The files covered here are:
 - `services/dashboard/Dockerfile`
 - `docker-compose.yml`
 
+This walkthrough also explains how the local Azure Blob emulator and browser-based storage explorer fit into the stack.
+
 ## `services/pipeline/Dockerfile`
 
 Current file:
@@ -214,12 +216,18 @@ volumes:
 - `services:`
   Starts the list of containers that Docker Compose should manage together.
 
-In this project, there are four services:
+In this project, there are seven services:
 
 - `pipeline`
 - `dashboard`
 - `postgres`
 - `adminer`
+- `azurite`
+- `azurestorageexplorer`
+- `migrate`
+
+`azurite` is a local Azure Storage emulator. It allows the pipeline to test Azure Blob uploads without requiring a real Azure account.
+`azurestorageexplorer` is a browser-based UI that connects to Azurite so you can verify uploaded blobs from a web page.
 
 ### `pipeline` service
 
@@ -256,8 +264,14 @@ In this project, there are four services:
 - `- postgres`
   Indicates the pipeline depends on Postgres being started first.
 
-- `command: ["python", "run_pipeline.py", "--source", "openweather", "--history-hours", "72"]`
-  Overrides or restates the default command and runs the pipeline.
+- `- migrate`
+  Ensures schema migrations are run before the batch job starts.
+
+- `- azurite`
+  Makes the local Blob emulator available when Azure Blob publishing is enabled.
+
+- `command: ["python", "-m", "pipeline.cli", "--source", "openweather", "--history-hours", "72"]`
+  Runs the packaged pipeline module instead of the older script-style entrypoint.
 
 - `restart: "no"`
   Tells Docker not to restart this service automatically.
@@ -360,6 +374,69 @@ In this project, there are four services:
 - `- postgres`
   Indicates the dependency.
 
+### `azurite` service
+
+- `azurite:`
+  Names the Azure Storage emulator service.
+
+- `image: mcr.microsoft.com/azure-storage/azurite`
+  Pulls the official Azurite image.
+
+- `command: ["azurite-blob", "--blobHost", "0.0.0.0", "--blobPort", "10000", "--location", "/data"]`
+  Starts the Blob emulator endpoint and stores emulator data under `/data`.
+
+- `ports:`
+  Publishes the Blob emulator to the host.
+
+- `- "10000:10000"`
+  Makes the Blob endpoint reachable on `http://localhost:10000`.
+
+- `volumes:`
+  Persists emulator state across restarts.
+
+- `- azurite_data:/data`
+  Stores Blob emulator data in a named Docker volume.
+
+### `azurestorageexplorer` service
+
+- `azurestorageexplorer:`
+  Names the browser-based Azure Storage explorer service.
+
+- `image: sebagomez/azurestorageexplorer:3.1.0`
+  Pulls a third-party web UI for browsing Azure Storage-compatible services.
+
+- `ports:`
+  Publishes the explorer UI on the host.
+
+- `- "8081:8080"`
+  Makes the explorer available at `http://localhost:8081`.
+
+- `environment:`
+  Preconfigures the explorer for the local Azurite setup.
+
+- `AZURITE: "true"`
+  Tells the explorer it is connecting to Azurite rather than a standard Azure public endpoint.
+
+- `AZURE_STORAGE_CONNECTIONSTRING: ${AZURE_STORAGE_CONNECTION_STRING}`
+  Reuses the same connection string that the pipeline uses for Blob uploads.
+
+- `depends_on:`
+  Starts the explorer after Azurite has started.
+
+- `azurite:`
+  Declares the dependency on the Blob emulator.
+
+### `migrate` service
+
+- `migrate:`
+  Names the one-time schema migration service.
+
+- `command: ["alembic", "upgrade", "head"]`
+  Applies the latest PostgreSQL schema before the pipeline starts.
+
+- `restart: "no"`
+  Runs once and exits after migrations complete.
+
 ### Named volumes
 
 - `volumes:`
@@ -367,6 +444,9 @@ In this project, there are four services:
 
 - `postgres_data:`
   Declares a named Docker volume used by the Postgres service.
+
+- `azurite_data:`
+  Declares a named Docker volume used by the Azurite service.
 
 ## Practical summary
 
@@ -380,13 +460,57 @@ Docker Compose does the following:
 
 1. builds the pipeline and dashboard images
 2. starts Postgres
-3. starts the pipeline job
-4. starts the React dashboard server
-5. starts Adminer
+3. waits until Postgres passes its healthcheck
+4. starts Azurite for local Blob uploads
+5. runs schema migration
+6. starts the pipeline job only after migration succeeds
+7. starts the React dashboard server
+8. starts Adminer
+9. starts the browser-based Azure Storage explorer
 
 The important idea is that:
 
 - the pipeline writes data into `./data`
+- the pipeline can also upload the gold Parquet artifact into Azurite when Azure Blob publishing is enabled
 - the dashboard primarily reads PostgreSQL through its backend API
 - `./data` remains useful for optional compatibility exports
 - Adminer helps you inspect Postgres visually
+- the browser explorer lets you verify the Blob artifact under container `gold` and path `exports/`
+
+## Azurite verification flow
+
+Use this sequence to verify the local Azure Blob path after running `docker compose up --build`:
+
+1. Confirm the pipeline completed successfully:
+
+```bash
+docker compose logs pipeline
+```
+
+2. Confirm Azurite accepted the upload:
+
+```bash
+docker compose logs azurite --tail=200
+```
+
+Healthy log lines include:
+
+```text
+PUT /devstoreaccount1/gold?restype=container ... 201
+PUT /devstoreaccount1/gold/exports/air_pollution_gold.parquet ... 201
+```
+
+3. Open the browser explorer:
+
+```text
+http://localhost:8081
+```
+
+4. Browse to:
+
+- container: `gold`
+- path: `exports/`
+- blob: `air_pollution_gold.parquet`
+
+5. If the explorer shows `0 objects`, clear the path and retry with `exports/`.
+Do not use `gold/exports/` inside the selected `gold` container.

--- a/docs/setup/local_postgresql_first_workflow.md
+++ b/docs/setup/local_postgresql_first_workflow.md
@@ -38,11 +38,15 @@ GOLD_DIR=./data/gold
 
 USE_POSTGRES=1
 WRITE_GOLD_PARQUET=0
+WRITE_GOLD_AZURE_BLOB=0
 POSTGRES_HOST=localhost
 POSTGRES_PORT=5432
 POSTGRES_DB=cityair
 POSTGRES_USER=cityair
 POSTGRES_PASSWORD=cityair
+AZURE_STORAGE_CONNECTION_STRING=
+AZURE_BLOB_CONTAINER=gold
+AZURE_BLOB_PATH=exports/{table_name}.parquet
 
 ```
 
@@ -50,6 +54,7 @@ Notes:
 
 - `USE_POSTGRES=1` keeps PostgreSQL as the primary gold-data target.
 - `WRITE_GOLD_PARQUET=0` disables Parquet unless you explicitly want a secondary export for debugging or compatibility.
+- `WRITE_GOLD_AZURE_BLOB=0` keeps Azure Blob publishing disabled during normal local DB-first work unless you are explicitly testing the Blob path.
 - `CITIES_SOURCE=postgres` means normal pipeline runs read cities from the database.
 - `CITIES_FILE` is still used for the seed/import step.
 
@@ -123,6 +128,7 @@ Optional checks:
 
 - inspect `geocoding_cache` to confirm cached coordinates were stored
 - enable `WRITE_GOLD_PARQUET=1` only if you intentionally want a secondary Parquet export
+- enable `WRITE_GOLD_AZURE_BLOB=1` only if you intentionally want to test Blob publishing
 
 ## 6. Run DB-native tests
 
@@ -149,6 +155,7 @@ For local debugging:
 - use local paths such as `./data/raw` and `./data/gold`
 - keep `USE_POSTGRES=1`
 - leave `WRITE_GOLD_PARQUET=0` unless you need a file artifact for dashboard debugging
+- leave `WRITE_GOLD_AZURE_BLOB=0` unless you are testing the Azurite or Azure upload path
 
 The current dashboard still reads Parquet, so dashboard debugging is a temporary exception to the DB-first runtime path.
 The React dashboard runs from `services/dashboard/server.py` and reads PostgreSQL-backed data through `/api/dashboard`.

--- a/docs/setup/run_and_debug_guide.md
+++ b/docs/setup/run_and_debug_guide.md
@@ -25,6 +25,7 @@ What they are used for on this branch:
 - `pandas`, `pyarrow`: CSV and Parquet data handling
 - `requests`: OpenWeather API calls
 - `pydantic`, `pydantic-settings`, `python-dotenv`: environment/config loading
+- `azure-storage-blob`: optional Azure Blob upload for the gold Parquet artifact
 - `duckdb`: included as a dependency, not currently required by the main runtime path
 - `sqlalchemy`, `psycopg[binary]`: PostgreSQL connectivity
 - `alembic`: PostgreSQL schema versioning and bootstrap
@@ -129,22 +130,18 @@ DATA_DIR=./data
 RAW_DIR=./data/raw
 GOLD_DIR=./data/gold
 
-# Optional cloud storage settings left unused in local Parquet flow
-GOLD_STORAGE_BACKEND=local
-AZURE_BLOB_CONTAINER=
-AZURE_GOLD_PREFIX=
-AZURE_STORAGE_CONNECTION_STRING=
-AZURE_STORAGE_ACCOUNT_NAME=
-AZURE_STORAGE_ACCOUNT_KEY=
-
 # PostgreSQL is the primary gold target
 USE_POSTGRES=1
 WRITE_GOLD_PARQUET=0
+WRITE_GOLD_AZURE_BLOB=0
 POSTGRES_HOST=localhost
 POSTGRES_PORT=5432
 POSTGRES_DB=cityair
 POSTGRES_USER=cityair
 POSTGRES_PASSWORD=cityair
+AZURE_STORAGE_CONNECTION_STRING=
+AZURE_BLOB_CONTAINER=gold
+AZURE_BLOB_PATH=exports/{table_name}.parquet
 
 ```
 
@@ -155,6 +152,7 @@ POSTGRES_PASSWORD=cityair
 - `DATA_DIR`, `RAW_DIR`, and `GOLD_DIR` must use local paths, not `/app/...` container paths.
 - `USE_POSTGRES=1` keeps PostgreSQL as the primary gold-data target during local runs.
 - `WRITE_GOLD_PARQUET=0` keeps Parquet export disabled unless you explicitly want a secondary file artifact.
+- `WRITE_GOLD_AZURE_BLOB=0` keeps Azure Blob publishing disabled unless you explicitly want to test the Blob upload path.
 
 ### Exact commands to run locally without Docker
 
@@ -191,6 +189,7 @@ These are the expected results:
 - PostgreSQL stores raw OpenWeather air-pollution responses and extract metadata for the DB-first migration path
 - PostgreSQL stores the gold dataset in `air_pollution_gold`
 - `data/gold/air_pollution_gold.parquet` exists only if `WRITE_GOLD_PARQUET=1`
+- Azure Blob publishing only runs if `WRITE_GOLD_AZURE_BLOB=1`
 - the dashboard server starts successfully on port `8501`
 - the dashboard shows row and city metrics
 
@@ -343,11 +342,13 @@ For this repository, Docker Compose starts these services:
 - `dashboard`: React frontend served by the Python dashboard server on port `8501`
 - `postgres`: PostgreSQL on port `5432`
 - `adminer`: Adminer UI on port `8080`
+- `azurite`: local Azure Blob emulator on port `10000`
+- `azurestorageexplorer`: browser-based Azure Storage explorer on port `8081`
 
 Important behavior:
 
 - The `pipeline` container is expected to finish and exit after it completes successfully.
-- The `dashboard`, `postgres`, and `adminer` containers should stay running.
+- The `dashboard`, `postgres`, `adminer`, `azurite`, and `azurestorageexplorer` containers should stay running.
 
 ### How to install Docker Compose on Windows and macOS
 
@@ -474,6 +475,13 @@ If you prefer detached mode:
 docker compose up --build -d
 ```
 
+If you want a completely fresh local state for PostgreSQL and Azurite, use:
+
+```bash
+docker compose down -v
+docker compose up --build
+```
+
 #### Step 7: Check whether the application is running properly
 
 Run:
@@ -487,6 +495,9 @@ Expected result on a healthy run:
 - `dashboard` is `Up`
 - `postgres` is `Up`
 - `adminer` is `Up`
+- `azurite` is `Up`
+- `azurestorageexplorer` is `Up`
+- `migrate` should show `Exited (0)` after applying the schema
 - `pipeline` may show `Exited (0)` after finishing, and that is expected
 
 Check container logs:
@@ -501,8 +512,64 @@ Healthy signs:
 - The pipeline logs end without a traceback
 - The pipeline logs include completion output
 - The dashboard logs show the dashboard server started successfully
+- The Azurite logs show Blob API requests if Blob publishing is enabled
 
-#### Step 8: Verify outputs
+#### Step 8: Verify Azurite Blob publishing
+
+Use this sequence when `WRITE_GOLD_AZURE_BLOB=1`.
+
+1. Confirm the pipeline completed successfully:
+
+```bash
+docker compose logs pipeline
+```
+
+2. Confirm Azurite received the Blob upload:
+
+```bash
+docker compose logs azurite --tail=200
+```
+
+Healthy signs include log lines like:
+
+```text
+PUT /devstoreaccount1/gold?restype=container ... 201
+PUT /devstoreaccount1/gold/exports/air_pollution_gold.parquet ... 201
+```
+
+3. Open the browser explorer:
+
+```text
+http://localhost:8081
+```
+
+The explorer is preconfigured for Azurite through Docker Compose and should open already authenticated.
+
+4. Browse to the uploaded artifact:
+
+- container: `gold`
+- path inside container: `exports/`
+- blob name: `air_pollution_gold.parquet`
+
+The full blob path is:
+
+```text
+gold / exports/air_pollution_gold.parquet
+```
+
+Important:
+
+- `gold` is the container name
+- the path inside that container is `exports/`
+- do not use `gold/exports/` as the path inside the explorer
+
+5. Optional verification:
+
+- download the blob from the explorer UI
+- confirm the file is non-empty
+- compare its size or contents with any local Parquet export if `WRITE_GOLD_PARQUET=1`
+
+#### Step 9: Verify outputs
 
 After the pipeline finishes, these checks should pass:
 
@@ -510,6 +577,7 @@ After the pipeline finishes, these checks should pass:
 2. The raw cache exists under `data/raw`.
 3. The dashboard opens at <http://localhost:8501>.
 4. Adminer opens at <http://localhost:8080>.
+5. Azure Storage Explorer opens at <http://localhost:8081>.
 
 Optional checks:
 
@@ -521,8 +589,10 @@ Notes:
 
 - On this branch, Postgres is part of the normal runtime path and should stay enabled.
 - Parquet export remains optional and only runs when `WRITE_GOLD_PARQUET=1`.
+- Azure Blob publishing remains optional and only runs when `WRITE_GOLD_AZURE_BLOB=1`.
+- The checked-in `.env.example` uses an Azurite connection string so Blob uploads can be tested locally through Docker Compose.
 
-#### Step 9: Stop the application
+#### Step 10: Stop the application
 
 ```bash
 docker compose down
@@ -575,9 +645,24 @@ This stack uses:
 
 - `8501` for the dashboard
 - `8080` for Adminer
+- `8081` for the browser-based Azure Storage explorer
+- `10000` for Azurite Blob storage
 - `5432` for Postgres
 
 If one of those ports is already in use, stop the other app or change the port mapping in `docker-compose.yml`.
+
+#### The browser explorer shows `0 objects` but Azurite logs show `201`
+
+This usually means the explorer is browsing the wrong path prefix.
+
+Use:
+
+- container: `gold`
+- path: `exports/`
+
+Do not use:
+
+- `gold/exports/`
 
 ## 6. Source references used for this guide
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ pydantic>=2.7
 pydantic-settings>=2.3
 python-dotenv>=1.0
 APScheduler>=3.10
+azure-storage-blob>=12.26
 duckdb>=1.0
 sqlalchemy>=2.0
 alembic>=1.13

--- a/services/pipeline/Dockerfile
+++ b/services/pipeline/Dockerfile
@@ -7,10 +7,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
  && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel
 RUN pip install --no-cache-dir -r /app/requirements.txt
 
 COPY pyproject.toml /app/pyproject.toml
-COPY services/pipeline /app
+COPY alembic.ini /app/alembic.ini
+COPY migrations /app/migrations
+COPY services/pipeline /app/services/pipeline
 COPY configs /app/configs
 RUN pip install --no-cache-dir --no-build-isolation --no-deps /app
 

--- a/services/pipeline/src/pipeline/common/config.py
+++ b/services/pipeline/src/pipeline/common/config.py
@@ -3,7 +3,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 class Settings(BaseSettings):
     # OpenWeather
-    openweather_api_key: str = "7842b53c6510964cf8c2ee80d5feaab2"
+    openweather_api_key: str = "CHANGEME"
     history_hours: int = 72
     max_calls_per_minute: int = 50
     cities_source: str = "postgres"
@@ -17,11 +17,15 @@ class Settings(BaseSettings):
     # PostgreSQL is the primary gold target; Parquet is optional.
     use_postgres: bool = True
     write_gold_parquet: bool = False
+    write_gold_azure_blob: bool = False
     postgres_host: str = "postgres"
     postgres_port: int = 5432
     postgres_db: str = "cityair"
     postgres_user: str = "cityair"
     postgres_password: str = "cityair"
+    azure_storage_connection_string: str = ""
+    azure_blob_container: str = "gold"
+    azure_blob_path: str = "exports/{table_name}.parquet"
 
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 

--- a/services/pipeline/src/pipeline/load/storage.py
+++ b/services/pipeline/src/pipeline/load/storage.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from io import BytesIO
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -13,9 +14,10 @@ from ..common.config import settings
 
 @dataclass(frozen=True)
 class PublishResult:
-    table_name: str | None
-    gold_path: Path | None
-    rows: int
+    table_name: str | None = None
+    gold_path: Path | None = None
+    azure_blob_path: str | None = None
+    rows: int = 0
 
 
 GOLD_UPSERT_REQUIRED_COLUMNS = {
@@ -34,6 +36,60 @@ GOLD_UPSERT_REQUIRED_COLUMNS = {
 
 def _build_postgres_engine():
     return create_engine(settings.postgres_sqlalchemy_url)
+
+
+def _import_azure_blob_clients():
+    try:
+        from azure.core.exceptions import ResourceExistsError
+        from azure.storage.blob import BlobServiceClient
+    except ImportError as exc:
+        raise ImportError(
+            "Azure Blob publishing requires azure-storage-blob. Install dependencies from requirements.txt."
+        ) from exc
+
+    return BlobServiceClient, ResourceExistsError
+
+
+def _build_blob_service_client():
+    connection_string = settings.azure_storage_connection_string.strip()
+    if not connection_string:
+        raise ValueError(
+            "WRITE_GOLD_AZURE_BLOB=1 requires AZURE_STORAGE_CONNECTION_STRING to be set"
+        )
+
+    BlobServiceClient, _ = _import_azure_blob_clients()
+    return BlobServiceClient.from_connection_string(connection_string)
+
+
+def _resolve_azure_blob_path(table_name: str) -> str:
+    blob_path = settings.azure_blob_path.strip()
+    if not blob_path:
+        blob_path = f"{table_name}.parquet"
+    return blob_path.format(table_name=table_name)
+
+
+def _upload_gold_to_azure_blob(gold_df: pd.DataFrame, table_name: str) -> str:
+    container_name = settings.azure_blob_container.strip()
+    if not container_name:
+        raise ValueError("WRITE_GOLD_AZURE_BLOB=1 requires AZURE_BLOB_CONTAINER to be set")
+
+    blob_path = _resolve_azure_blob_path(table_name)
+    service_client = _build_blob_service_client()
+    _, ResourceExistsError = _import_azure_blob_clients()
+
+    container_client = service_client.get_container_client(container_name)
+    try:
+        container_client.create_container()
+    except ResourceExistsError:
+        pass
+
+    parquet_bytes = BytesIO()
+    gold_df.to_parquet(parquet_bytes, index=False)
+    parquet_bytes.seek(0)
+
+    blob_client = service_client.get_blob_client(container=container_name, blob=blob_path)
+    blob_client.upload_blob(parquet_bytes.getvalue(), overwrite=True)
+    return blob_path
 
 
 def _build_gold_table(table_name: str) -> sa.Table:
@@ -127,6 +183,7 @@ def _upsert_gold_rows(engine, gold_df: pd.DataFrame, table_name: str) -> None:
 def publish_outputs(gold_df: pd.DataFrame, gold_dir: Path, table_name: str) -> PublishResult:
     postgres_table: str | None = None
     gold_path: Path | None = None
+    azure_blob_path: str | None = None
 
     if settings.use_postgres:
         engine = _build_postgres_engine()
@@ -137,7 +194,17 @@ def publish_outputs(gold_df: pd.DataFrame, gold_dir: Path, table_name: str) -> P
         gold_path = gold_dir / f"{table_name}.parquet"
         gold_df.to_parquet(gold_path, index=False)
 
-    if postgres_table is None and gold_path is None:
-        raise ValueError("At least one load target must be enabled: USE_POSTGRES=1 or WRITE_GOLD_PARQUET=1")
+    if settings.write_gold_azure_blob:
+        azure_blob_path = _upload_gold_to_azure_blob(gold_df=gold_df, table_name=table_name)
 
-    return PublishResult(table_name=postgres_table, gold_path=gold_path, rows=len(gold_df))
+    if postgres_table is None and gold_path is None and azure_blob_path is None:
+        raise ValueError(
+            "At least one load target must be enabled: USE_POSTGRES=1, WRITE_GOLD_PARQUET=1, or WRITE_GOLD_AZURE_BLOB=1"
+        )
+
+    return PublishResult(
+        table_name=postgres_table,
+        gold_path=gold_path,
+        azure_blob_path=azure_blob_path,
+        rows=len(gold_df),
+    )

--- a/services/pipeline/src/pipeline/orchestration/__init__.py
+++ b/services/pipeline/src/pipeline/orchestration/__init__.py
@@ -27,6 +27,7 @@ class PipelineRunResult:
     history_hours: int
     raw_records: list[RawAirPollutionRecord]
     gold_path: Path | None
+    azure_blob_path: str | None
     postgres_table: str | None
     rows: int
 
@@ -133,6 +134,7 @@ def run_pipeline_job(source: str = "openweather", history_hours: int | None = No
             history_hours=resolved_history_hours,
             raw_records=raw_records,
             gold_path=publish_result.gold_path,
+            azure_blob_path=publish_result.azure_blob_path,
             postgres_table=publish_result.table_name,
             rows=len(gold_df),
         )
@@ -142,6 +144,7 @@ def run_pipeline_job(source: str = "openweather", history_hours: int | None = No
             extra={
                 "pipeline_run_id": result.pipeline_run_id,
                 "gold_path": str(result.gold_path) if result.gold_path is not None else None,
+                "azure_blob_path": result.azure_blob_path,
                 "postgres_table": result.postgres_table,
                 "rows": result.rows,
             },

--- a/services/pipeline/tests/test_orchestration_runner.py
+++ b/services/pipeline/tests/test_orchestration_runner.py
@@ -74,6 +74,7 @@ def test_run_pipeline_job_is_importable_and_returns_result(
     assert result.history_hours == 72
     assert result.rows == 1
     assert result.gold_path is None
+    assert result.azure_blob_path is None
     assert result.postgres_table == "air_pollution_gold"
     assert captured["cities_path"] is None
     assert len(captured["raw_records"]) == 1

--- a/services/pipeline/tests/test_storage_publish.py
+++ b/services/pipeline/tests/test_storage_publish.py
@@ -35,6 +35,7 @@ def test_publish_outputs_supports_postgres_only(
 ):
     monkeypatch.setattr(storage.settings, "use_postgres", True)
     monkeypatch.setattr(storage.settings, "write_gold_parquet", False)
+    monkeypatch.setattr(storage.settings, "write_gold_azure_blob", False)
 
     captured: dict[str, object] = {}
 
@@ -69,7 +70,89 @@ def test_publish_outputs_supports_postgres_only(
     }
     assert result.table_name == "air_pollution_gold"
     assert result.gold_path is None
+    assert result.azure_blob_path is None
     assert result.rows == 1
+
+
+def test_publish_outputs_supports_azure_blob_only(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    monkeypatch.setattr(storage.settings, "use_postgres", False)
+    monkeypatch.setattr(storage.settings, "write_gold_parquet", False)
+    monkeypatch.setattr(storage.settings, "write_gold_azure_blob", True)
+    monkeypatch.setattr(storage.settings, "azure_blob_container", "gold")
+    monkeypatch.setattr(storage.settings, "azure_blob_path", "exports/{table_name}.parquet")
+    monkeypatch.setattr(
+        storage.settings,
+        "azure_storage_connection_string",
+        "UseDevelopmentStorage=true",
+    )
+
+    captured: dict[str, object] = {}
+
+    class DummyContainerClient:
+        def create_container(self):
+            captured["container_created"] = True
+
+    class DummyBlobClient:
+        def upload_blob(self, payload, overwrite):
+            captured["upload"] = {"size": len(payload), "overwrite": overwrite}
+
+    class DummyBlobServiceClient:
+        @classmethod
+        def from_connection_string(cls, connection_string):
+            captured["connection_string"] = connection_string
+            return cls()
+
+        def get_container_client(self, container_name):
+            captured["container_name"] = container_name
+            return DummyContainerClient()
+
+        def get_blob_client(self, *, container, blob):
+            captured["blob_target"] = {"container": container, "blob": blob}
+            return DummyBlobClient()
+
+    monkeypatch.setattr(
+        storage,
+        "_import_azure_blob_clients",
+        lambda: (DummyBlobServiceClient, type("DummyExists", (Exception,), {})),
+    )
+
+    result = storage.publish_outputs(
+        gold_df=build_gold_df(),
+        gold_dir=tmp_path,
+        table_name="air_pollution_gold",
+    )
+
+    assert captured["connection_string"] == "UseDevelopmentStorage=true"
+    assert captured["container_name"] == "gold"
+    assert captured["blob_target"] == {
+        "container": "gold",
+        "blob": "exports/air_pollution_gold.parquet",
+    }
+    assert captured["upload"]["overwrite"] is True
+    assert captured["upload"]["size"] > 0
+    assert result.table_name is None
+    assert result.gold_path is None
+    assert result.azure_blob_path == "exports/air_pollution_gold.parquet"
+    assert result.rows == 1
+
+
+def test_publish_outputs_requires_connection_string_for_azure_blob(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    monkeypatch.setattr(storage.settings, "use_postgres", False)
+    monkeypatch.setattr(storage.settings, "write_gold_parquet", False)
+    monkeypatch.setattr(storage.settings, "write_gold_azure_blob", True)
+    monkeypatch.setattr(storage.settings, "azure_storage_connection_string", "")
+    monkeypatch.setattr(storage.settings, "azure_blob_container", "gold")
+
+    with pytest.raises(ValueError, match=r"AZURE_STORAGE_CONNECTION_STRING"):
+        storage.publish_outputs(
+            gold_df=build_gold_df(),
+            gold_dir=tmp_path,
+            table_name="air_pollution_gold",
+        )
 
 
 def test_prepare_gold_rows_requires_lineage_columns():
@@ -109,6 +192,7 @@ def test_publish_outputs_requires_at_least_one_target(
 ):
     monkeypatch.setattr(storage.settings, "use_postgres", False)
     monkeypatch.setattr(storage.settings, "write_gold_parquet", False)
+    monkeypatch.setattr(storage.settings, "write_gold_azure_blob", False)
 
     with pytest.raises(ValueError, match=r"At least one load target must be enabled"):
         storage.publish_outputs(


### PR DESCRIPTION
## Summary
- adds optional Azure Blob publishing for the gold Parquet artifact while keeping PostgreSQL as the primary gold target
- adds local Azurite support in Docker Compose so Blob publishing can be tested without a real Azure account
- adds a browser-based storage explorer for local verification
- updates docs and tests to cover the Azurite workflow

## What Changed
- added Azure Blob config and publish support in the pipeline load path
- kept existing `USE_POSTGRES` and `WRITE_GOLD_PARQUET` behavior intact
- added Azurite and browser explorer services to `docker-compose.yml`
- hardened Compose startup with Postgres healthchecks and migration completion dependencies
- documented the local Blob verification flow and expected blob path
- added tests for Azure Blob publishing and config validation

## Local Validation
- verified PostgreSQL remains the primary gold target
- verified pipeline completion with Azure Blob publishing enabled
- verified Azurite accepted the upload
- verified the blob is visible in the browser explorer at:
  - container: `gold`
  - path: `exports/air_pollution_gold.parquet`

## Notes
- the Azurite browser explorer requires `AZURITE=true` plus the Azurite connection string in Compose to browse the blob path correctly