### PR TITLE
AIR-109 fix fresh start pipeline bugs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ Use these docs when you want to install, run, debug, or validate the project loc
 
 - `setup/local_postgresql_first_workflow.md`
 - `setup/run_and_debug_guide.md`
+- `setup/fresh_start_pipeline_bringup.md`
 - `setup/postgresql_migrations_guide.md`
 - `setup/docker_and_compose_walkthrough.md`
 - `setup/github_quality_gates_setup.md`

--- a/docs/setup/fresh_start_pipeline_bringup.md
+++ b/docs/setup/fresh_start_pipeline_bringup.md
@@ -1,0 +1,271 @@
+# Fresh-Start Pipeline Bring-Up
+
+This guide records the exact steps and commands used to bring up the City Air Tracker pipeline from a clean local Docker state and verify that:
+
+- PostgreSQL is populated
+- the gold Parquet artifact is uploaded to local Azure-compatible Blob storage through Azurite
+- the dashboard is serving real data
+
+## Goal
+
+At the end of this sequence, the local environment should provide:
+
+- PostgreSQL with seeded cities, raw responses, and gold rows
+- Azurite with the uploaded blob at `gold / exports/air_pollution_gold.parquet`
+- the dashboard available at `http://localhost:8501`
+- the browser-based Blob explorer available at `http://localhost:8081`
+
+## Important note about this run
+
+During this verification session, the local machine could not rebuild Docker images because the Docker `buildx` plugin was missing.
+
+Because of that, the fresh-start validation used the local fixed pipeline source mounted into the existing pipeline container image for the seed and ETL commands.
+
+That means:
+
+- PostgreSQL, Azurite, dashboard, and explorer still ran normally through Docker Compose
+- the pipeline code path used the current local source tree mounted read-only into the container
+
+This was the exact successful procedure used in the session.
+
+## 1. Remove local containers and volumes
+
+Start from a clean state:
+
+```bash
+docker compose down -v
+```
+
+This removes:
+
+- Compose-managed containers
+- the PostgreSQL named volume
+- the Azurite named volume
+
+## 2. Start the base services
+
+Bring up the local database, migration, dashboard, Adminer, Azurite, and browser explorer:
+
+```bash
+docker compose up -d postgres azurite migrate dashboard adminer azurestorageexplorer
+```
+
+## 3. Confirm services are up
+
+Check the service status:
+
+```bash
+docker compose ps
+```
+
+Healthy expected services:
+
+- `postgres`
+- `azurite`
+- `dashboard`
+- `adminer`
+- `azurestorageexplorer`
+
+## 4. Seed cities into PostgreSQL
+
+Because this validation used the fixed local source tree mounted into the container, the city-seed command was run like this:
+
+```bash
+docker compose run --no-deps --rm -v "$PWD/services/pipeline/src:/workspace/pipeline_src:ro" pipeline sh -lc 'PYTHONPATH=/workspace/pipeline_src python -m pipeline.cli --seed-cities'
+```
+
+This loads the configured city CSV into the `cities` table in PostgreSQL.
+
+## 5. Run the ETL pipeline
+
+Run the full ETL pipeline against the clean local stack:
+
+```bash
+docker compose run --no-deps --rm -v "$PWD/services/pipeline/src:/workspace/pipeline_src:ro" pipeline sh -lc 'PYTHONPATH=/workspace/pipeline_src python -m pipeline.cli --source openweather --history-hours 72'
+```
+
+Expected log shape:
+
+```text
+INFO pipeline.orchestration - Starting pipeline
+INFO pipeline.orchestration - Pipeline complete
+```
+
+## 6. Verify the Blob upload in Azurite
+
+Check Azurite logs:
+
+```bash
+docker compose logs azurite --tail=100
+```
+
+Expected lines:
+
+```text
+PUT /devstoreaccount1/gold?restype=container HTTP/1.1" 201
+PUT /devstoreaccount1/gold/exports/air_pollution_gold.parquet HTTP/1.1" 201
+```
+
+These confirm that:
+
+- the `gold` container exists
+- the Parquet blob was uploaded successfully
+
+### Verify the archived Parquet file in the browser explorer
+
+Open:
+
+```text
+http://localhost:8081
+```
+
+Then verify:
+
+1. the `gold` container exists
+2. the path `exports/` contains `air_pollution_gold.parquet`
+3. the blob appears in the browser explorer list
+
+Expected blob location:
+
+- container: `gold`
+- path: `exports/air_pollution_gold.parquet`
+
+Important path note:
+
+- inside the explorer, browse `exports/`
+- do not use `gold/exports/` after the `gold` container is already selected
+
+## 7. Verify PostgreSQL data
+
+Check row counts and latest pipeline status:
+
+```bash
+docker exec practicum-city-air-tracker-postgres-1 psql -U cityair -d cityair -c "select count(*) as cities from cities; select count(*) as raw_rows from raw_air_pollution_responses; select count(*) as gold_rows from air_pollution_gold; select id, run_id, status, city_count, raw_response_count, gold_row_count from pipeline_runs order by id desc limit 3;"
+```
+
+Successful output from the verified run:
+
+```text
+cities = 4
+raw_rows = 4
+gold_rows = 288
+status = succeeded
+city_count = 4
+gold_row_count = 288
+```
+
+### Verify that the PostgreSQL tables exist
+
+Check that the DB-first schema was created:
+
+```bash
+docker exec practicum-city-air-tracker-postgres-1 psql -U cityair -d cityair -c "\dt"
+```
+
+Expected tables include:
+
+- `cities`
+- `geocoding_cache`
+- `pipeline_runs`
+- `raw_air_pollution_responses`
+- `air_pollution_gold`
+
+### Verify inserted city rows
+
+```bash
+docker exec practicum-city-air-tracker-postgres-1 psql -U cityair -d cityair -c "select id, city, country_code, state, is_active from cities order by id;"
+```
+
+Expected result:
+
+- seeded city rows exist
+- city count is greater than zero
+
+### Verify inserted raw-response rows
+
+```bash
+docker exec practicum-city-air-tracker-postgres-1 psql -U cityair -d cityair -c "select id, city_id, request_start_utc, request_end_utc, record_count from raw_air_pollution_responses order by id;"
+```
+
+Expected result:
+
+- one raw-response row exists per processed city for the requested window
+- `record_count` is populated
+
+### Verify inserted gold rows
+
+```bash
+docker exec practicum-city-air-tracker-postgres-1 psql -U cityair -d cityair -c "select geo_id, ts, aqi, aqi_category, risk_score from air_pollution_gold order by geo_id, ts limit 20;"
+```
+
+Expected result:
+
+- gold rows exist
+- timestamps, AQI values, categories, and risk scores are populated
+- the data is queryable by the dashboard backend
+
+## 8. Verify the dashboard API
+
+Query the dashboard backend directly:
+
+```bash
+curl -s http://localhost:8501/api/dashboard | head -c 1200
+```
+
+Expected result:
+
+- JSON payload is returned
+- `rows` contains real data
+- `summary` fields are populated
+
+## 9. Open the local UIs
+
+Blob explorer:
+
+```text
+http://localhost:8081
+```
+
+Expected blob location:
+
+- container: `gold`
+- path: `exports/air_pollution_gold.parquet`
+
+Dashboard:
+
+```text
+http://localhost:8501
+```
+
+Adminer:
+
+```text
+http://localhost:8080
+```
+
+## Full command list
+
+For convenience, here is the exact successful command sequence in order:
+
+```bash
+docker compose down -v
+docker compose up -d postgres azurite migrate dashboard adminer azurestorageexplorer
+docker compose ps
+docker compose run --no-deps --rm -v "$PWD/services/pipeline/src:/workspace/pipeline_src:ro" pipeline sh -lc 'PYTHONPATH=/workspace/pipeline_src python -m pipeline.cli --seed-cities'
+docker compose run --no-deps --rm -v "$PWD/services/pipeline/src:/workspace/pipeline_src:ro" pipeline sh -lc 'PYTHONPATH=/workspace/pipeline_src python -m pipeline.cli --source openweather --history-hours 72'
+docker compose logs azurite --tail=100
+docker exec practicum-city-air-tracker-postgres-1 psql -U cityair -d cityair -c "select count(*) as cities from cities; select count(*) as raw_rows from raw_air_pollution_responses; select count(*) as gold_rows from air_pollution_gold; select id, run_id, status, city_count, raw_response_count, gold_row_count from pipeline_runs order by id desc limit 3;"
+curl -s http://localhost:8501/api/dashboard | head -c 1200
+```
+
+## Final verified state
+
+From the successful run in this session:
+
+- pipeline run id: `20260407T165520Z`
+- cities: `4`
+- raw rows: `4`
+- gold rows: `288`
+- blob path: `gold / exports/air_pollution_gold.parquet`
+- dashboard API returned populated JSON
+

--- a/services/pipeline/src/pipeline/cli.py
+++ b/services/pipeline/src/pipeline/cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+from pathlib import Path
 
 from pipeline.common.config import settings
 from pipeline.extract.cities import seed_cities_from_file
@@ -15,7 +16,7 @@ def main() -> None:
     args = parser.parse_args()
 
     if args.seed_cities:
-        seed_cities_from_file(settings.cities_file)
+        seed_cities_from_file(Path(settings.cities_file))
         return
 
     run_pipeline_job(source=args.source, history_hours=args.history_hours)

--- a/services/pipeline/src/pipeline/extract/geocoding.py
+++ b/services/pipeline/src/pipeline/extract/geocoding.py
@@ -26,27 +26,43 @@ def _build_postgres_engine():
 
 
 def _lookup_city_id(connection, city: str, country_code: str, state: str | None) -> int:
-    row = connection.execute(
-        text(
-            """
-            SELECT id
-            FROM cities
-            WHERE city = :city
-              AND country_code = :country_code
-              AND (
-                (:state IS NULL AND state IS NULL)
-                OR state = :state
-              )
-            ORDER BY id
-            LIMIT 1
-            """
-        ),
-        {
-            "city": city,
-            "country_code": country_code,
-            "state": state,
-        },
-    ).fetchone()
+    if state is None:
+        row = connection.execute(
+            text(
+                """
+                SELECT id
+                FROM cities
+                WHERE city = :city
+                  AND country_code = :country_code
+                  AND state IS NULL
+                ORDER BY id
+                LIMIT 1
+                """
+            ),
+            {
+                "city": city,
+                "country_code": country_code,
+            },
+        ).fetchone()
+    else:
+        row = connection.execute(
+            text(
+                """
+                SELECT id
+                FROM cities
+                WHERE city = :city
+                  AND country_code = :country_code
+                  AND state = :state
+                ORDER BY id
+                LIMIT 1
+                """
+            ),
+            {
+                "city": city,
+                "country_code": country_code,
+                "state": state,
+            },
+        ).fetchone()
 
     if row is None:
         raise ValueError(

--- a/services/pipeline/tests/test_geocoding_cache.py
+++ b/services/pipeline/tests/test_geocoding_cache.py
@@ -149,3 +149,33 @@ def test_geocode_city_writes_postgres_cache_on_miss(monkeypatch: pytest.MonkeyPa
     assert float(row[2]) == 2.3522
     assert row[3] == "Paris"
     assert row[4] == "FR"
+
+
+def test_lookup_city_id_handles_null_state(tmp_path: Path):
+    engine = _build_sqlite_engine(tmp_path / "geo-null-state.db")
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                INSERT INTO cities (city, country_code, state, is_active)
+                VALUES ('Paris', 'FR', NULL, 1)
+                """
+            )
+        )
+
+        assert geocoding._lookup_city_id(connection, city="Paris", country_code="FR", state=None) == 1
+
+
+def test_lookup_city_id_handles_non_null_state(tmp_path: Path):
+    engine = _build_sqlite_engine(tmp_path / "geo-state.db")
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                INSERT INTO cities (city, country_code, state, is_active)
+                VALUES ('Toronto', 'CA', 'ON', 1)
+                """
+            )
+        )
+
+        assert geocoding._lookup_city_id(connection, city="Toronto", country_code="CA", state="ON") == 1

--- a/services/pipeline/tests/test_run_pipeline_cities_file.py
+++ b/services/pipeline/tests/test_run_pipeline_cities_file.py
@@ -1,4 +1,5 @@
 from argparse import Namespace
+from pathlib import Path
 import pytest
 
 import pipeline.cli as pipeline_cli
@@ -63,4 +64,4 @@ def test_main_supports_seed_cities(monkeypatch: pytest.MonkeyPatch):
 
     run_pipeline.main()
 
-    assert captured == {"cities_file": pipeline_cli.settings.cities_file}
+    assert captured == {"cities_file": Path(pipeline_cli.settings.cities_file)}


### PR DESCRIPTION
A clean local startup from scratch exposed two blocking bugs in the pipeline path.

First, python -m pipeline.cli --seed-cities failed because the CLI passed settings.cities_file as a plain string, while seed_cities_from_file(...) expects a Path. On a fresh database, this prevents the cities table from being populated at all.

Second, once cities were seeded, the pipeline failed during geocoding city lookup on PostgreSQL. The query in pipeline.extract.geocoding._lookup_city_id(...) used a NULL comparison pattern that caused psycopg.errors.AmbiguousParameter when state was NULL. That blocked extraction for cities without a state value and prevented the pipeline from loading raw or gold data.

Because of these two issues, a fresh local run after docker compose down -v could not complete end to end without a workaround. The expected behavior is that a clean local startup should allow city seeding, pipeline execution, PostgreSQL loading, Azurite Blob upload, and dashboard population without manual intervention.