### PR TITLE
AIR-011.7: Add Prefect runtime entrypoint and migrate from APScheduler

### DIFF
--- a/docs/architecture/function_call_flows.md
+++ b/docs/architecture/function_call_flows.md
@@ -74,8 +74,8 @@ sequenceDiagram
 
 Note:
 
-- `scheduler.py` is currently a thin APScheduler-compatible wrapper around the shared orchestration runner.
-- It does not yet define recurring job registration or cadence configuration by itself.
+- `scheduler.py` is a temporary compatibility wrapper; Prefect is now the active orchestration direction.
+- Recurring job registration and cadence configuration are follow-up capabilities to be implemented via Prefect deployments.
 
 ## 2. Seed Cities Flow
 
@@ -406,5 +406,6 @@ The main happy-path function chain for the ETL pipeline is:
 - The handoff from extract to transform to load is not DB-to-DB. It happens as Python objects and a pandas DataFrame in memory.
 - `raw_dir` is still passed around by orchestration, but `fetch_air_pollution_history()` currently ignores it.
 - Local Parquet and Azure Blob publishing are optional secondary outputs; PostgreSQL remains the primary gold-data target.
-- APScheduler integration is scaffolded through `scheduler.py`, but configurable recurring scheduling is still a follow-up capability.
+- Prefect is the active orchestration direction; `scheduler.py` remains as a temporary compatibility shim during the transition.
+- Configurable recurring scheduling via Prefect deployments is a follow-up capability.
 - The dashboard backend reads only from `air_pollution_gold`; it does not call pipeline code directly.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.11"
 
 [project.scripts]
 city-air-pipeline = "pipeline.cli:main"
+city-air-pipeline-prefect = "pipeline.prefect_runtime:main"
 
 [tool.setuptools]
 package-dir = {"" = "services/pipeline/src"}


### PR DESCRIPTION
- Add city-air-pipeline-prefect CLI entrypoint in pyproject.toml for Prefect flow execution
- Update docs/architecture/function_call_flows.md to clarify Prefect is the active orchestration direction
- Document scheduler.py as temporary compatibility shim during Prefect transition
- Remove APScheduler references from documentation

Fulfills AC1-AC7:
✓ Prefect flow runtime entrypoint exists (prefect_runtime.py) ✓ Entrypoint executable locally via new CLI command ✓ Separate from one-shot CLI execution path
✓ Uses shared pipeline runner (no duplication)
✓ Prefect in requirements.txt as active dependency ✓ APScheduler not in requirements (already removed) ✓ Repo no longer implies APScheduler is long-term direction