### PR TITLE
AIR-011.4: Improve logging and observability for in-process pipeline execution

### DIFF
--- a/services/pipeline/src/pipeline/orchestration/__init__.py
+++ b/services/pipeline/src/pipeline/orchestration/__init__.py
@@ -99,11 +99,25 @@ def run_pipeline_job(source: str = "openweather", history_hours: int | None = No
         window_end_utc=end,
     )
 
-    log.info("Starting pipeline", extra={"source": source, "history_hours": resolved_history_hours})
+    log.info(
+        "Pipeline starting",
+        extra={
+            "run_id": run_id,
+            "pipeline_run_id": pipeline_run_id,
+            "source": source,
+            "history_hours": resolved_history_hours,
+            "window_start_utc": start.isoformat(),
+            "window_end_utc": end.isoformat(),
+        },
+    )
     city_count = 0
     raw_records: list[RawAirPollutionRecord] = []
 
     try:
+        log.info(
+            "Extract stage starting",
+            extra={"run_id": run_id, "pipeline_run_id": pipeline_run_id, "source": source},
+        )
         raw_records, city_count = run_extract_stage(
             raw_dir=raw_dir,
             start=start,
@@ -111,10 +125,44 @@ def run_pipeline_job(source: str = "openweather", history_hours: int | None = No
             run_id=run_id,
             pipeline_run_id=pipeline_run_id,
         )
+        log.info(
+            "Extract stage complete",
+            extra={
+                "run_id": run_id,
+                "pipeline_run_id": pipeline_run_id,
+                "city_count": city_count,
+                "raw_response_count": len(raw_records),
+            },
+        )
+
+        log.info(
+            "Transform stage starting",
+            extra={"run_id": run_id, "pipeline_run_id": pipeline_run_id, "raw_response_count": len(raw_records)},
+        )
         gold_df = run_transform_stage(raw_records=raw_records)
         if not gold_df.empty:
             gold_df["pipeline_run_id"] = pipeline_run_id
+        log.info(
+            "Transform stage complete",
+            extra={"run_id": run_id, "pipeline_run_id": pipeline_run_id, "gold_row_count": len(gold_df)},
+        )
+
+        log.info(
+            "Load stage starting",
+            extra={"run_id": run_id, "pipeline_run_id": pipeline_run_id, "gold_row_count": len(gold_df)},
+        )
         publish_result = run_load_stage(gold_df=gold_df, gold_dir=gold_dir)
+        log.info(
+            "Load stage complete",
+            extra={
+                "run_id": run_id,
+                "pipeline_run_id": pipeline_run_id,
+                "postgres_table": publish_result.table_name,
+                "gold_path": str(publish_result.gold_path) if publish_result.gold_path is not None else None,
+                "azure_blob_path": publish_result.azure_blob_path,
+                "rows": publish_result.rows,
+            },
+        )
 
         update_pipeline_run_status(
             run_id,
@@ -140,17 +188,30 @@ def run_pipeline_job(source: str = "openweather", history_hours: int | None = No
         )
 
         log.info(
-            "Pipeline complete",
+            "Pipeline succeeded",
             extra={
+                "run_id": run_id,
                 "pipeline_run_id": result.pipeline_run_id,
+                "city_count": city_count,
+                "raw_response_count": len(raw_records),
+                "gold_row_count": result.rows,
+                "postgres_table": result.postgres_table,
                 "gold_path": str(result.gold_path) if result.gold_path is not None else None,
                 "azure_blob_path": result.azure_blob_path,
-                "postgres_table": result.postgres_table,
-                "rows": result.rows,
             },
         )
         return result
     except Exception as exc:
+        log.exception(
+            "Pipeline failed",
+            extra={
+                "run_id": run_id,
+                "pipeline_run_id": pipeline_run_id,
+                "source": source,
+                "city_count": city_count or None,
+                "raw_response_count": len(raw_records) or None,
+            },
+        )
         update_pipeline_run_status(
             run_id,
             PipelineRunStatusUpdate(

--- a/services/pipeline/src/pipeline/prefect_runtime.py
+++ b/services/pipeline/src/pipeline/prefect_runtime.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import argparse
 from collections.abc import Callable
-from typing import Any, TypeVar
+from typing import Any, Optional, TypeVar
 
 from pipeline.common.config import settings
 from pipeline.orchestration import run_pipeline_job
@@ -33,7 +33,7 @@ def _ensure_prefect_available() -> None:
 
 
 @prefect_flow(name="city-air-pipeline")
-def run_pipeline_flow(source: str = "openweather", history_hours: int | None = None):
+def run_pipeline_flow(source: str = "openweather", history_hours: Optional[int] = None):
     """Prefect-facing flow wrapper around the shared pipeline runner."""
     _ensure_prefect_available()
     return run_pipeline_job(source=source, history_hours=history_hours)

--- a/services/pipeline/tests/test_orchestration_runner.py
+++ b/services/pipeline/tests/test_orchestration_runner.py
@@ -1,6 +1,7 @@
+import logging
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Optional
+from typing import Any, Optional
 
 import pandas as pd
 import pytest
@@ -20,8 +21,8 @@ def test_run_pipeline_job_is_importable_and_returns_result(
     monkeypatch.setattr(orchestration.settings, "raw_dir", str(tmp_path / "raw"))
     monkeypatch.setattr(orchestration.settings, "gold_dir", str(tmp_path / "gold"))
 
-    captured: dict[str, object] = {}
-    status_updates: list[object] = []
+    captured: dict[str, Any] = {}
+    status_updates: list[Any] = []
 
     def fake_read_cities(path: Optional[Path]) -> list[CitySpec]:
         captured["cities_path"] = path
@@ -120,3 +121,129 @@ def test_run_pipeline_job_fails_fast_when_cities_file_missing(
     assert len(status_updates) == 1
     assert status_updates[0][1].status == "failed"
     assert "CITIES_FILE path does not exist" in status_updates[0][1].error_message
+
+
+# ---------------------------------------------------------------------------
+# Logging behaviour tests
+# ---------------------------------------------------------------------------
+
+class _LogCapture(logging.Handler):
+    """Minimal handler that accumulates LogRecord objects."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+
+def _make_monkeypatched_run(monkeypatch, tmp_path, *, inject_failure: Optional[Exception] = None):
+    """Set up all monkeypatches needed for a run_pipeline_job call.
+
+    If *inject_failure* is not None it is raised by the transform stage so
+    tests can verify failure-path logging.
+    """
+    monkeypatch.setattr(orchestration.settings, "cities_file", str(tmp_path / "cities.csv"))
+    monkeypatch.setattr(orchestration.settings, "cities_source", "postgres")
+    monkeypatch.setattr(orchestration.settings, "raw_dir", str(tmp_path / "raw"))
+    monkeypatch.setattr(orchestration.settings, "gold_dir", str(tmp_path / "gold"))
+
+    def fake_read_cities(path: Optional[Path]) -> list[CitySpec]:
+        return [CitySpec(city="Toronto", country_code="CA", state="ON")]
+
+    def fake_fetch_air_pollution_history(**kwargs):
+        return RawAirPollutionRecord(
+            raw_response_id=1,
+            pipeline_run_id=1,
+            city_id=1,
+            city="Toronto",
+            country_code="CA",
+            lat=43.6535,
+            lon=-79.3839,
+            geo_id="Toronto,CA:43.6535,-79.3839",
+            request_start_utc=kwargs["start"],
+            request_end_utc=kwargs["end"],
+            status_code=200,
+            record_count=1,
+            payload_json={"list": []},
+            fetched_at=kwargs["end"],
+        )
+
+    def fake_build_gold(*, raw_records):
+        if inject_failure is not None:
+            raise inject_failure
+        return pd.DataFrame([{"geo_id": "Toronto,CA", "ts": "2026-03-17T00:00:00Z"}])
+
+    def fake_publish_outputs(**kwargs):
+        return PublishResult(table_name="air_pollution_gold", gold_path=None, rows=1)
+
+    monkeypatch.setattr(orchestration, "read_cities", fake_read_cities)
+    monkeypatch.setattr(orchestration, "geocode_city", lambda **_: SimpleNamespace(lat=43.6535, lon=-79.3839))
+    monkeypatch.setattr(orchestration, "fetch_air_pollution_history", fake_fetch_air_pollution_history)
+    monkeypatch.setattr(orchestration, "build_gold_from_raw_records", fake_build_gold)
+    monkeypatch.setattr(orchestration, "publish_outputs", fake_publish_outputs)
+    monkeypatch.setattr(orchestration, "create_pipeline_run", lambda **kwargs: 101)
+    monkeypatch.setattr(orchestration, "update_pipeline_run_status", lambda run_id, update: None)
+
+
+def test_success_path_emits_lifecycle_log_messages(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    _make_monkeypatched_run(monkeypatch, tmp_path)
+
+    orch_logger = logging.getLogger("pipeline.orchestration")
+    capture = _LogCapture()
+    orch_logger.addHandler(capture)
+    try:
+        result = run_pipeline_job(source="openweather", history_hours=24)
+    finally:
+        orch_logger.removeHandler(capture)
+
+    messages = [r.getMessage() for r in capture.records]
+
+    assert any("Pipeline starting" in m for m in messages), "Missing 'Pipeline starting' log"
+    assert any("Extract stage starting" in m for m in messages), "Missing 'Extract stage starting' log"
+    assert any("Extract stage complete" in m for m in messages), "Missing 'Extract stage complete' log"
+    assert any("Transform stage starting" in m for m in messages), "Missing 'Transform stage starting' log"
+    assert any("Transform stage complete" in m for m in messages), "Missing 'Transform stage complete' log"
+    assert any("Load stage starting" in m for m in messages), "Missing 'Load stage starting' log"
+    assert any("Load stage complete" in m for m in messages), "Missing 'Load stage complete' log"
+    assert any("Pipeline succeeded" in m for m in messages), "Missing 'Pipeline succeeded' log"
+
+    # run_id and pipeline_run_id must appear in pipeline-starting record
+    start_record = next(r for r in capture.records if "Pipeline starting" in r.getMessage())
+    assert start_record.run_id == result.run_id  # type: ignore[attr-defined]
+    assert start_record.pipeline_run_id == 101  # type: ignore[attr-defined]
+
+    # success record carries summary counts
+    success_record = next(r for r in capture.records if "Pipeline succeeded" in r.getMessage())
+    assert success_record.run_id == result.run_id  # type: ignore[attr-defined]
+    assert success_record.city_count == 1  # type: ignore[attr-defined]
+    assert success_record.raw_response_count == 1  # type: ignore[attr-defined]
+    assert success_record.gold_row_count == 1  # type: ignore[attr-defined]
+
+
+def test_failure_path_emits_exception_log_before_reraise(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    boom = RuntimeError("transform exploded")
+    _make_monkeypatched_run(monkeypatch, tmp_path, inject_failure=boom)
+
+    orch_logger = logging.getLogger("pipeline.orchestration")
+    capture = _LogCapture()
+    orch_logger.addHandler(capture)
+    try:
+        with pytest.raises(RuntimeError, match="transform exploded"):
+            run_pipeline_job(source="openweather", history_hours=24)
+    finally:
+        orch_logger.removeHandler(capture)
+
+    error_records = [r for r in capture.records if r.levelno >= logging.ERROR]
+    assert error_records, "Expected at least one ERROR/EXCEPTION log before re-raise"
+
+    failure_record = error_records[0]
+    assert "Pipeline failed" in failure_record.getMessage()
+    assert failure_record.pipeline_run_id == 101  # type: ignore[attr-defined]
+    # exc_info should be attached so the traceback is visible in logs
+    assert failure_record.exc_info is not None

--- a/services/pipeline/tests/test_prefect_runtime.py
+++ b/services/pipeline/tests/test_prefect_runtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import sys
 
 import pytest
@@ -41,3 +42,56 @@ def test_run_pipeline_flow_raises_helpful_error_when_prefect_is_missing():
 
     with pytest.raises(RuntimeError, match="Prefect is not installed"):
         prefect_runtime.run_pipeline_flow()
+
+
+def test_prefect_flow_does_not_add_duplicate_lifecycle_logs(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """run_pipeline_flow must not add extra lifecycle logs on top of those
+    emitted by the shared runner (run_pipeline_job). The wrapper itself
+    should not emit its own start/complete messages that duplicate what the
+    orchestration layer already records."""
+
+    orchestration_messages: list[str] = []
+    wrapper_messages: list[str] = []
+
+    def fake_run_pipeline_job(source, history_hours):
+        inner_log = logging.getLogger("pipeline.orchestration")
+        inner_log.info("Pipeline starting")
+        inner_log.info("Pipeline succeeded")
+        return {"source": source, "history_hours": history_hours}
+
+    monkeypatch.setattr(prefect_runtime, "_ensure_prefect_available", lambda: None)
+    monkeypatch.setattr(prefect_runtime, "run_pipeline_job", fake_run_pipeline_job)
+
+    class _Capture(logging.Handler):
+        def __init__(self, store: list) -> None:
+            super().__init__()
+            self.store = store
+
+        def emit(self, record: logging.LogRecord) -> None:
+            self.store.append(record.getMessage())
+
+    orch_handler = _Capture(orchestration_messages)
+    wrapper_handler = _Capture(wrapper_messages)
+
+    orch_logger = logging.getLogger("pipeline.orchestration")
+    wrapper_logger = logging.getLogger("pipeline.prefect_runtime")
+    orch_logger.addHandler(orch_handler)
+    wrapper_logger.addHandler(wrapper_handler)
+    try:
+        prefect_runtime.run_pipeline_flow(source="openweather", history_hours=24)
+    finally:
+        orch_logger.removeHandler(orch_handler)
+        wrapper_logger.removeHandler(wrapper_handler)
+
+    # The shared runner messages must be present.
+    assert any("Pipeline starting" in m for m in orchestration_messages)
+    assert any("Pipeline succeeded" in m for m in orchestration_messages)
+
+    # The Prefect wrapper must not emit its own duplicative lifecycle logs.
+    duplicates = [
+        m for m in wrapper_messages
+        if any(kw in m for kw in ("Pipeline starting", "Pipeline complete", "Pipeline succeeded", "Pipeline failed"))
+    ]
+    assert duplicates == [], f"Prefect wrapper emitted duplicate lifecycle logs: {duplicates}"


### PR DESCRIPTION
- Emit stage-boundary log messages (Pipeline starting, Extract/Transform/Load
  stage starting/complete, Pipeline succeeded, Pipeline failed) from
  run_pipeline_job, each carrying run_id, pipeline_run_id, and relevant
  counts as structured extra fields
- Replace bare 'Pipeline complete' log with richer 'Pipeline succeeded' record
  including city_count, raw_response_count, gold_row_count, and destination info
- Add log.exception on failure path so full traceback is captured before re-raise
- Fix int | None union syntax in prefect_runtime to Optional[int] for broader
  Python 3.9 compatibility
- Add test_success_path_emits_lifecycle_log_messages: verifies all stage logs
  and that run_id/pipeline_run_id/counts appear on the correct records
- Add test_failure_path_emits_exception_log_before_reraise: verifies ERROR-level
  log with exc_info is emitted before the exception propagates
- Add test_prefect_flow_does_not_add_duplicate_lifecycle_logs: verifies the
  Prefect wrapper does not re-emit start/complete messages already emitted by
  the shared runner