### PR TITLE
AIR-013.4 add env profile switching workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,7 @@ celerybeat.pid
 
 # Environments
 .env
+.env.*
 .envrc
 .venv
 env/

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Use `docs/setup/run_and_debug_guide.md` for:
 
 - local Python installation
 - Python library installation
-- local non-Docker `.env` configuration
+- local non-Docker `.env.local` configuration
 - local VS Code debugging
 - Docker Compose installation
 - Docker Compose configuration, launch, and verification
@@ -33,6 +33,25 @@ Use `docs/setup/local_postgresql_first_workflow.md` for the consolidated local P
 - DB-native test commands
 
 Use `docs/setup/azure_postgresql_configuration.md` for managed Azure Database for PostgreSQL configuration guidance.
+Use `docs/setup/environment_profiles_guide.md` to keep separate local and Azure env files without overwriting your normal Docker settings.
+Use `bash scripts/generate_env_profiles.sh` to create `.env.local` and `.env.azure` from the tracked templates in `configs/env/`.
+Use `ENV_FILE=.env.azure ...` when you want to run the app, migrations, or Docker Compose against the Azure profile.
+
+## Run modes
+
+This repo currently supports three practical run modes:
+
+1. Local without Docker
+   Uses `.env.local` with local filesystem paths and a local PostgreSQL instance.
+2. Local with Docker
+   Uses `.env.local` with Docker Compose, container paths, local Postgres, and Azurite.
+3. Cloud-connected
+   Uses `ENV_FILE=.env.azure` so the app or local containers point at Azure-backed resources such as Azure Database for PostgreSQL and Azure Blob Storage.
+
+Important:
+
+- the cloud-connected mode changes which resources the app talks to
+- it does not by itself deploy the app into Azure
 
 ## One-command local environment setup
 
@@ -92,7 +111,7 @@ Quick sequence:
 Optional Blob flow for local testing:
 
 1. set `WRITE_GOLD_AZURE_BLOB=1`
-2. keep the Azurite connection string from `.env.example`
+2. keep the Azurite connection string from `.env.local`
 3. run `docker compose up --build`
 4. open the browser explorer at `http://localhost:8081`
 5. confirm the blob exists under container `gold` at `exports/air_pollution_gold.parquet`

--- a/configs/env/azure.template
+++ b/configs/env/azure.template
@@ -1,0 +1,37 @@
+# Azure profile template for cloud-connected runs.
+# Generate `.env.local` and `.env.azure` with `bash scripts/generate_env_profiles.sh`.
+
+# ---- Pipeline ----
+OPENWEATHER_API_KEY=CHANGEME
+HISTORY_HOURS=72
+MAX_CALLS_PER_MINUTE=50
+CITIES_SOURCE=postgres
+CITIES_FILE=/app/configs/cities.csv
+
+# Container paths (Docker)
+DATA_DIR=/app/data
+RAW_DIR=/app/data/raw
+GOLD_DIR=/app/data/gold
+
+# PostgreSQL is the primary gold target
+USE_POSTGRES=1
+WRITE_GOLD_PARQUET=0
+WRITE_GOLD_AZURE_BLOB=0
+POSTGRES_HOST=YOUR_SERVER.postgres.database.azure.com
+POSTGRES_PORT=5432
+POSTGRES_DB=postgres
+POSTGRES_USER=YOUR_USER@YOUR_SERVER
+POSTGRES_PASSWORD=YOUR_PASSWORD
+POSTGRES_SSLMODE=require
+POSTGRES_SSLROOTCERT=
+ALEMBIC_DATABASE_URL=
+
+# Azure Blob publishing
+AZURE_STORAGE_CONNECTION_STRING=
+AZURE_STORAGE_ACCOUNT_URL=
+AZURE_STORAGE_CREDENTIAL=
+AZURE_BLOB_CONTAINER=gold
+AZURE_BLOB_PATH=exports/{table_name}.parquet
+
+# ---- Dashboard ----
+DASHBOARD_DATA_PATH=/app/data/gold/air_pollution_gold.parquet

--- a/configs/env/local.template
+++ b/configs/env/local.template
@@ -1,3 +1,6 @@
+# Local profile template.
+# Generate `.env.local` and `.env.azure` with `bash scripts/generate_env_profiles.sh`.
+
 # ---- Pipeline ----
 OPENWEATHER_API_KEY=CHANGEME
 HISTORY_HOURS=72

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     build:
       context: .
       dockerfile: services/pipeline/Dockerfile
-    env_file: .env
+    env_file: ${ENV_FILE:-.env.local}
     depends_on:
       postgres:
         condition: service_healthy
@@ -14,7 +14,7 @@ services:
     build:
       context: .
       dockerfile: services/pipeline/Dockerfile
-    env_file: .env
+    env_file: ${ENV_FILE:-.env.local}
     volumes:
       - ./data:/app/data
       - ./configs:/app/configs:ro
@@ -32,7 +32,7 @@ services:
     build:
       context: .
       dockerfile: services/dashboard/Dockerfile
-    env_file: .env
+    env_file: ${ENV_FILE:-.env.local}
     environment:
       POSTGRES_HOST: ${POSTGRES_HOST:-postgres}
       POSTGRES_PORT: ${POSTGRES_PORT:-5432}

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ Use these docs when you want to install, run, debug, or validate the project loc
 - `setup/run_and_debug_guide.md`
 - `setup/fresh_start_pipeline_bringup.md`
 - `setup/postgresql_migrations_guide.md`
+- `setup/environment_profiles_guide.md`
 - `setup/docker_and_compose_walkthrough.md`
 - `setup/github_quality_gates_setup.md`
 

--- a/docs/setup/azure_postgresql_configuration.md
+++ b/docs/setup/azure_postgresql_configuration.md
@@ -10,6 +10,10 @@ The same PostgreSQL code path is used for:
 
 Switching targets should only require environment variable changes.
 
+If you keep Azure values in `.env.azure`, run commands with
+`ENV_FILE=.env.azure` so the Azure profile is active without replacing your
+local `.env.local`.
+
 ## Environment Variables
 
 The PostgreSQL runtime path uses these settings:
@@ -97,7 +101,12 @@ To verify the Azure PostgreSQL configuration:
 
 - confirm the environment values point to the intended Azure server
 - confirm `POSTGRES_SSLMODE=require` or the required SSL mode for your setup
-- run the usual pipeline command
+- run the usual pipeline command, for example
+
+```bash
+ENV_FILE=.env.azure python -m pipeline.cli --source openweather --history-hours 72
+```
+
 - verify rows appear in the expected PostgreSQL tables, such as:
   - `pipeline_runs`
   - `raw_air_pollution_responses`

--- a/docs/setup/environment_profiles_guide.md
+++ b/docs/setup/environment_profiles_guide.md
@@ -1,0 +1,124 @@
+# Environment Profiles Guide
+
+This guide shows how to keep separate local and Azure environment settings
+without overwriting your normal Docker Compose development configuration.
+
+## Recommended layout
+
+Keep these files at the repository root:
+
+- `.env.local`
+  for the normal local Docker and local PostgreSQL workflow
+- `.env.azure`
+  for real Azure PostgreSQL and other cloud-only values
+- `configs/env/local.template`
+  tracked local starter template
+- `configs/env/azure.template`
+  tracked Azure starter template
+
+Only the tracked templates under `configs/env/` should be committed.
+
+## Create the Azure profile
+
+Generate both local and Azure profiles from the tracked templates:
+
+```bash
+bash scripts/generate_env_profiles.sh
+```
+
+This creates:
+
+- `.env.local` from `configs/env/local.template`
+- `.env.azure` from `configs/env/azure.template`
+
+Then replace the placeholders in `.env.azure` with your real Azure values.
+
+Example Azure PostgreSQL block:
+
+```dotenv
+USE_POSTGRES=1
+POSTGRES_HOST=YOUR_SERVER.postgres.database.azure.com
+POSTGRES_PORT=5432
+POSTGRES_DB=postgres
+POSTGRES_USER=YOUR_USER@YOUR_SERVER
+POSTGRES_PASSWORD=YOUR_PASSWORD
+POSTGRES_SSLMODE=require
+POSTGRES_SSLROOTCERT=
+```
+
+## Which file is active
+
+The application settings loader reads the file named by `ENV_FILE`.
+
+- if `ENV_FILE` is unset, the default is `.env.local`
+- if `ENV_FILE=.env.azure`, the Azure profile becomes active
+
+That means you can keep both files side by side without copying one over the
+other.
+
+## Supported run modes
+
+The env-profile workflow supports these run modes:
+
+1. Local without Docker
+   Run Python and Alembic directly on your machine, usually with `.env.local`
+   edited to use local filesystem paths and `POSTGRES_HOST=localhost`.
+2. Local with Docker
+   Run `docker compose up --build` with `.env.local` using the Docker-oriented
+   defaults from `configs/env/local.template`.
+3. Cloud-connected
+   Run local Python commands, Alembic commands, or Docker Compose with
+   `ENV_FILE=.env.azure` so the app uses Azure-backed services.
+
+Important:
+
+- the cloud-connected mode means the app runs locally or in local containers
+  while talking to cloud resources
+- it is not the same as deploying the app itself to Azure
+
+## Run with the Azure profile
+
+For local Python commands, prefix the command with `ENV_FILE=.env.azure`:
+
+```bash
+ENV_FILE=.env.azure python -m pipeline.cli --source openweather --history-hours 72
+```
+
+For Alembic commands:
+
+```bash
+ENV_FILE=.env.azure alembic current
+ENV_FILE=.env.azure alembic upgrade head
+```
+
+For Docker Compose:
+
+```bash
+ENV_FILE=.env.azure docker compose up --build
+```
+
+## Keep both profiles safely
+
+An easy workflow is:
+
+1. keep your local Docker settings in `.env.local`
+2. keep your Azure settings in `.env.azure`
+3. run commands with `ENV_FILE=.env.azure` only when you want the cloud profile
+
+## Alembic migrations
+
+Alembic uses the same shared settings path, so `ENV_FILE=.env.azure` switches
+the migration target to the Azure profile too.
+
+You can also set `ALEMBIC_DATABASE_URL` explicitly in `.env.azure` if you want
+the migration target to be fully explicit.
+
+## Security notes
+
+- never commit `.env.local` or `.env.azure`
+- commit only the tracked templates under `configs/env/`
+- prefer secret stores or deployment environment variables for shared or
+  production environments
+
+For Azure-specific PostgreSQL details, use
+[azure_postgresql_configuration.md](/home/eugen/code-the-dream-workspace/practicum-city-air-tracker/docs/setup/azure_postgresql_configuration.md).

--- a/docs/setup/local_postgresql_first_workflow.md
+++ b/docs/setup/local_postgresql_first_workflow.md
@@ -21,9 +21,9 @@ Before you start, make sure you have:
 
 If you have not set up Python yet, start with [run_and_debug_guide.md](/home/eugen/code-the-dream-workspace/practicum-city-air-tracker/docs/setup/run_and_debug_guide.md).
 
-## 1. Configure `.env`
+## 1. Configure `.env.local`
 
-Create `.env` from `.env.example`, then use local machine paths and PostgreSQL settings like these:
+Generate `.env.local` with `bash scripts/generate_env_profiles.sh`, then use local machine paths and PostgreSQL settings like these:
 
 ```dotenv
 OPENWEATHER_API_KEY=YOUR_REAL_KEY
@@ -156,7 +156,7 @@ pytest services/pipeline/tests/test_postgres_config.py \
 
 For local debugging:
 
-- keep the same PostgreSQL-first `.env` settings
+- keep the same PostgreSQL-first `.env.local` settings
 - use local paths such as `./data/raw` and `./data/gold`
 - keep `USE_POSTGRES=1`
 - leave `WRITE_GOLD_PARQUET=0` unless you need a file artifact for dashboard debugging

--- a/docs/setup/postgresql_migrations_guide.md
+++ b/docs/setup/postgresql_migrations_guide.md
@@ -17,7 +17,7 @@ Alembic is configured at the repository root:
 Alembic resolves the target database in this order:
 
 1. `ALEMBIC_DATABASE_URL`, if set
-2. the PostgreSQL connection values already defined in `.env`
+2. the PostgreSQL connection values already defined in the active env profile, which defaults to `.env.local`
 
 That means the normal application settings can drive migrations without adding a second required database configuration path.
 

--- a/docs/setup/run_and_debug_guide.md
+++ b/docs/setup/run_and_debug_guide.md
@@ -102,7 +102,7 @@ python -m pip install -r requirements.txt
 
 ## 3. Run locally without Docker
 
-If you want to run this project locally without Docker, use Python plus a virtual environment and set `.env` to local filesystem paths.
+If you want to run this project locally without Docker, use Python plus a virtual environment and set `.env.local` to local filesystem paths.
 
 For the most direct DB-first setup and validation path, use [local_postgresql_first_workflow.md](/home/eugen/code-the-dream-workspace/practicum-city-air-tracker/docs/setup/local_postgresql_first_workflow.md) alongside this guide.
 
@@ -111,11 +111,11 @@ Important:
 - PostgreSQL is the primary gold-data target on this branch.
 - The React dashboard reads PostgreSQL-backed data through the dashboard server API.
 - For running the application locally without Docker, you should have PostgreSQL available and keep `USE_POSTGRES=1`.
-- The checked-in `.env.example` is Docker-oriented, so you must change it for local runs.
+- The checked-in `configs/env/local.template` is Docker-oriented, so you must change the generated `.env.local` for local runs.
 
-### Exact `.env` values for local-without-Docker
+### Exact `.env.local` values for local-without-Docker
 
-Create `.env` from `.env.example`, then make it match this:
+Generate `.env.local` with `bash scripts/generate_env_profiles.sh`, then make it match this:
 
 ```dotenv
 # ---- Pipeline ----
@@ -161,7 +161,7 @@ AZURE_BLOB_PATH=exports/{table_name}.parquet
 
 ### Exact commands to run locally without Docker
 
-After your virtual environment is active and `.env` matches the values above:
+After your virtual environment is active and `.env.local` matches the values above:
 
 1. Seed cities into PostgreSQL:
 
@@ -221,9 +221,9 @@ Install the Python dependencies using the steps in section 2, then open the proj
 
 ### Important local-path note
 
-The checked-in `.env.example` file uses Docker container paths such as `/app/data` and `/app/configs/cities.csv`.
+The checked-in `configs/env/local.template` file uses Docker container paths such as `/app/data` and `/app/configs/cities.csv`.
 
-For local VS Code debugging, use local filesystem paths instead. In a real `.env` file, use absolute paths or project-relative paths, not `${workspaceFolder}`.
+For local VS Code debugging, use local filesystem paths instead. In a real `.env.local` file, use absolute paths or project-relative paths, not `${workspaceFolder}`.
 
 ```dotenv
 OPENWEATHER_API_KEY=YOUR_REAL_KEY
@@ -243,9 +243,9 @@ POSTGRES_USER=cityair
 POSTGRES_PASSWORD=cityair
 ```
 
-Because `.env` is loaded by the app at runtime, the safest approach is either:
+Because `.env.local` is loaded by the app at runtime, the safest approach is either:
 
-- temporarily edit `.env` for local debugging, or
+- temporarily edit `.env.local` for local debugging, or
 - add the environment variables directly in `.vscode/launch.json`
 
 ### Recommended `launch.json`
@@ -409,23 +409,23 @@ git pull
 
 Start Docker Desktop and wait until it reports that Docker is running.
 
-#### Step 3: Create your `.env` file
+#### Step 3: Create your `.env.local` file
 
 From the project root:
 
 ```bash
-cp .env.example .env
+bash scripts/generate_env_profiles.sh
 ```
 
 On Windows PowerShell:
 
 ```powershell
-Copy-Item .env.example .env
+wsl bash scripts/generate_env_profiles.sh
 ```
 
 #### Step 4: Set your OpenWeather API key
 
-Edit `.env` and replace:
+Edit `.env.local` and replace:
 
 ```dotenv
 OPENWEATHER_API_KEY=CHANGEME
@@ -433,7 +433,7 @@ OPENWEATHER_API_KEY=CHANGEME
 
 with your real key.
 
-For Docker Compose on this branch, the default `.env.example` paths are already set correctly:
+For Docker Compose on this branch, the default template paths are already set correctly:
 
 ```dotenv
 CITIES_FILE=/app/configs/cities.csv
@@ -595,7 +595,7 @@ Notes:
 - On this branch, Postgres is part of the normal runtime path and should stay enabled.
 - Parquet export remains optional and only runs when `WRITE_GOLD_PARQUET=1`.
 - Azure Blob publishing remains optional and only runs when `WRITE_GOLD_AZURE_BLOB=1`.
-- The checked-in `.env.example` uses an Azurite connection string so Blob uploads can be tested locally through Docker Compose.
+- The checked-in `configs/env/local.template` uses an Azurite connection string so Blob uploads can be tested locally through Docker Compose.
 
 #### Step 10: Stop the application
 
@@ -640,7 +640,7 @@ docker compose logs pipeline
 
 Check:
 
-- `OPENWEATHER_API_KEY` is set correctly in `.env`
+- `OPENWEATHER_API_KEY` is set correctly in `.env.local` or the active env profile
 - Your network can reach OpenWeather
 - You are not hitting API rate limits
 
@@ -675,7 +675,7 @@ Project files:
 
 - `docker-compose.yml`
 - `requirements.txt`
-- `.env.example`
+- `configs/env/local.template`
 - `README.md`
 - `services/pipeline/Dockerfile`
 - `services/dashboard/Dockerfile`

--- a/scripts/generate_env_profiles.sh
+++ b/scripts/generate_env_profiles.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FORCE=0
+
+if [[ "${1:-}" == "--force" || "${1:-}" == "-f" ]]; then
+  FORCE=1
+fi
+
+copy_profile() {
+  local source_file="$1"
+  local target_file="$2"
+
+  if [[ ! -f "$source_file" ]]; then
+    echo "Missing template: $source_file" >&2
+    exit 1
+  fi
+
+  if [[ -e "$target_file" && "$FORCE" -ne 1 ]]; then
+    echo "Skipping existing $target_file"
+    return
+  fi
+
+  cp "$source_file" "$target_file"
+  echo "Wrote $target_file"
+}
+
+copy_profile "$ROOT_DIR/configs/env/local.template" "$ROOT_DIR/.env.local"
+copy_profile "$ROOT_DIR/configs/env/azure.template" "$ROOT_DIR/.env.azure"
+
+echo
+echo "Profile generation complete."
+echo "Use .env.local by default, or set ENV_FILE=.env.azure for Azure commands."

--- a/services/pipeline/src/pipeline/common/config.py
+++ b/services/pipeline/src/pipeline/common/config.py
@@ -1,6 +1,11 @@
+import os
 from urllib.parse import quote, urlencode
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+def _resolve_env_file() -> str:
+    return os.getenv("ENV_FILE", ".env.local")
 
 
 class Settings(BaseSettings):
@@ -33,7 +38,7 @@ class Settings(BaseSettings):
     azure_blob_container: str = "gold"
     azure_blob_path: str = "exports/{table_name}.parquet"
 
-    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+    model_config = SettingsConfigDict(env_file=_resolve_env_file(), extra="ignore")
 
     @property
     def postgres_sqlalchemy_url(self) -> str:

--- a/services/pipeline/src/pipeline/extract/geocoding.py
+++ b/services/pipeline/src/pipeline/extract/geocoding.py
@@ -159,7 +159,7 @@ def geocode_city(raw_dir: Path, city: str, country_code: str, state: str | None 
             return cached
 
     if not settings.openweather_api_key or settings.openweather_api_key == "CHANGEME":
-        raise ValueError("OPENWEATHER_API_KEY must be set in .env")
+        raise ValueError("OPENWEATHER_API_KEY must be set in the active env profile")
 
     q = f"{city},{country_code}"
     if state:

--- a/services/pipeline/src/pipeline/extract/openweather_air_pollution.py
+++ b/services/pipeline/src/pipeline/extract/openweather_air_pollution.py
@@ -152,7 +152,7 @@ def fetch_air_pollution_history(
     del raw_dir
 
     if not settings.openweather_api_key or settings.openweather_api_key == "CHANGEME":
-        raise ValueError("OPENWEATHER_API_KEY must be set in .env")
+        raise ValueError("OPENWEATHER_API_KEY must be set in the active env profile")
 
     geo_id = _geo_id(city, country_code, lat, lon)
     engine = _build_postgres_engine()

--- a/services/pipeline/tests/test_env_file_selection.py
+++ b/services/pipeline/tests/test_env_file_selection.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+
+def _reload_config_module():
+    sys.modules.pop("pipeline.common.config", None)
+    return importlib.import_module("pipeline.common.config")
+
+
+def test_settings_default_to_dotenv_when_env_file_is_unset(monkeypatch):
+    monkeypatch.delenv("ENV_FILE", raising=False)
+
+    config = _reload_config_module()
+
+    assert config._resolve_env_file() == ".env.local"
+    assert config.Settings.model_config.get("env_file") == ".env.local"
+
+
+def test_settings_support_custom_env_file(monkeypatch, tmp_path: Path):
+    env_file = tmp_path / ".env.azure"
+    env_file.write_text("POSTGRES_HOST=azure.example\n", encoding="utf-8")
+
+    monkeypatch.setenv("ENV_FILE", str(env_file))
+
+    config = _reload_config_module()
+    settings = config.Settings()
+
+    assert config._resolve_env_file() == str(env_file)
+    assert config.Settings.model_config.get("env_file") == str(env_file)
+    assert settings.postgres_host == "azure.example"


### PR DESCRIPTION
## Summary

This PR adds a cleaner environment-profile workflow for local and Azure-connected runs.

It introduces `ENV_FILE`-based profile switching, makes `.env.local` the default local profile, adds a generator script for `.env.local` and `.env.azure`, and updates the setup docs so the supported run modes are clearer.

## What changed

- added `ENV_FILE` support in the pipeline settings loader
- updated Docker Compose services to use `${ENV_FILE:-.env.local}`
- added `scripts/generate_env_profiles.sh` to generate:
  - `.env.local`
  - `.env.azure`
- moved tracked env templates into:
  - `configs/env/local.template`
  - `configs/env/azure.template`
- added focused test coverage for env-file selection
- updated docs to explain:
  - local without Docker
  - local with Docker
  - cloud-connected runs using `ENV_FILE=.env.azure`

## Why

The repo previously relied on a single `.env` path and did not provide a clean way to keep separate local and Azure-backed configurations side by side.

This change makes it easier to:
- keep local Docker and local non-Docker settings in `.env.local`
- keep Azure-backed settings in `.env.azure`
- switch runtime targets without copying files around
- document the difference between local execution and cloud-connected execution more clearly

