### PR TITLE
AIR-014.2: Implement feature engineering for ML enrichment #105

### DIFF
--- a/services/pipeline/src/pipeline/ml/features.py
+++ b/services/pipeline/src/pipeline/ml/features.py
@@ -1,0 +1,107 @@
+'''This module contains functions for feature engineering for machine learning models in the pipeline. 
+   It takes in 3 columns from OpenWeather data (city_id, ts, pm2_5) and gives output with 5 columns added namely
+        1. hour_of_day
+        2. day_of_week
+        3. pm2_5_prev_1h
+        4. pm2_5_roll_3h
+        5. pm2_5_roll_12h
+    Features are computed per city_id and are deterministic'''
+from __future__ import annotations
+import pandas as pd
+
+
+def add_time_features(df: pd.DataFrame) -> pd.DataFrame:
+    '''Add calendar features derived from the ts timestamp.
+    
+    Adds:
+        hour_of_day: int 0-23, hour of day in UTC.
+        day_of_week: int 0-6, Monday=0 (pandas convention).
+
+    These features are deterministic and capture the daily rhythm
+    (rush-hour traffic, heating cycles) and weekly rhythm (weekday vs
+    weekend) in air quality. Both are pulled directly from `ts` and do
+    not depend on any other row, so they are safe even on short history.
+    '''
+    out = df.copy()
+    out['hour_of_day'] = out['ts'].dt.hour
+    out['day_of_week'] = out['ts'].dt.dayofweek
+    return out
+
+
+def add_lag_features(df: pd.DataFrame) -> pd.DataFrame:
+    '''Add the per-city PM2.5 lag feature.
+
+    Adds:
+        pm2_5_prev_1h: float. PM2.5 from the previous hour for the same
+            city. NaN for the first row of each city (no prior observation
+            exists — this is the explicit short-history behavior).
+
+    Notes:
+        - The lag is computed per city_id so one city's history never
+        leaks into another city's row.
+        - Input rows are sorted by (city_id, ts) defensively before
+        shifting, so the output is identical regardless of the input
+        row order. Determinism is required by parent story #103.
+    '''
+    out = df.copy()
+    sorted_df = out.sort_values(['city_id', 'ts'])
+    out['pm2_5_prev_1h'] = sorted_df.groupby('city_id')['pm2_5'].shift(1)
+    return out
+
+
+def add_rolling_features(df: pd.DataFrame) -> pd.DataFrame:
+    '''Add the per-city PM2.5 rolling mean features.
+
+    Adds:
+        pm2_5_roll_3h: float. Trailing 3-hour mean of PM2.5 for the same
+            city, inclusive of the current hour. With min_periods=1, the
+            mean is computed over whatever observations are available so
+            far: 1 value at row 1, 2 values at row 2, the full 3-hour
+            window from row 3 onward. No NaN is produced from short history.
+        pm2_5_roll_12h: float. Trailing 12-hour mean of PM2.5 for the same
+            city, inclusive of the current hour. Same partial-window
+            semantics as pm2_5_roll_3h — rows 1 through 11 of each city
+            use whatever data is available so far.
+
+    Notes:
+        - Rolling means are computed per city_id, so one city's history
+        never leaks into another city's row.
+        - Input rows are sorted by (city_id, ts) defensively before the
+        rolling computation, so the output is identical regardless of
+        input row order. Determinism is required by parent story #103.
+        - pandas' rolling.mean() skips NaN values within a window, so a
+        single missing PM2.5 reading does not poison the window mean.
+    '''
+    out = df.copy()
+    sorted_df = out.sort_values(['city_id', 'ts'])
+    out['pm2_5_roll_3h'] = sorted_df.groupby('city_id')['pm2_5'].rolling(window=3, min_periods=1).mean().reset_index(level=0, drop=True)
+    out['pm2_5_roll_12h'] = sorted_df.groupby('city_id')['pm2_5'].rolling(window=12, min_periods=1).mean().reset_index(level=0, drop=True)
+    return out
+
+
+def add_ml_features(df: pd.DataFrame) -> pd.DataFrame:
+    '''Add all 5 deterministic ML features to a city-air-quality DataFrame.
+
+    This is the public entry point for the ml/features module. It composes
+    the three smaller helpers in order: add_time_features → add_lag_features
+    → add_rolling_features. The input DataFrame is never mutated — each
+    helper returns a new copy.
+
+    Required input columns:
+        city_id (int), ts (UTC datetime), pm2_5 (float; may contain NaN).
+
+    Adds: hour_of_day, day_of_week, pm2_5_prev_1h, pm2_5_roll_3h, pm2_5_roll_12h.
+
+    Raises:
+        KeyError — if any required input column is missing. Failing fast
+        here is friendlier than producing a confusing pandas error deeper
+        in the chain.
+    '''
+    required = {'city_id', 'ts', 'pm2_5'}
+    missing = required - set(df.columns)
+    if missing:
+        raise KeyError(f"add_ml_features is missing required columns: {sorted(missing)}")
+    out = add_time_features(df)
+    out = add_lag_features(out)
+    out = add_rolling_features(out)
+    return out

--- a/services/pipeline/tests/test_features.py
+++ b/services/pipeline/tests/test_features.py
@@ -1,0 +1,134 @@
+'''Tests for pipeline.ml.features — verifies feature shape, per-city scoping,
+    short-history NaN behavior, determinism, and input-mutation safety.'''
+from datetime import datetime, timezone
+import pandas as pd
+import pytest
+from pipeline.ml.features import add_ml_features, add_time_features, add_lag_features, add_rolling_features
+
+
+def _make_df(rows: list[tuple[int, int, float]]) -> pd.DataFrame:
+    return pd.DataFrame([
+        {'city_id': c, 'ts': datetime(2026, 4, 28, h, tzinfo=timezone.utc), 'pm2_5': p}
+        for (c, h, p) in rows
+    ])
+
+
+def test_add_ml_features_adds_all_five_columns():
+    '''add_ml_features adds all 5 expected feature columns.'''
+    df = _make_df([
+        (1, 0, 10.0),
+        (1, 1, 20.0),
+        (2, 0, 30.0),
+    ])
+    result = add_ml_features(df)
+    expected_cols = {'hour_of_day', 'day_of_week', 'pm2_5_prev_1h', 'pm2_5_roll_3h', 'pm2_5_roll_12h'}
+    assert expected_cols.issubset(result.columns)
+
+
+def test_lag_first_row_per_city_is_nan():
+    '''The first row for each city has NaN in the lag feature, since no prior
+    observation exists for that city.'''
+    df = _make_df([
+        (1, 0, 10.0),
+        (1, 1, 20.0),
+        (2, 0, 30.0),
+        (2, 1, 40.0),
+    ])
+    result = add_lag_features(df)
+    for city_id in [1, 2]:
+        city_rows = result[result['city_id'] == city_id].sort_values('ts')
+        first_row = city_rows.iloc[0]
+        assert pd.isna(first_row['pm2_5_prev_1h'])
+        assert city_rows.iloc[1]['pm2_5_prev_1h'] == city_rows.iloc[0]['pm2_5']
+
+
+def test_lag_handles_single_row_city():
+    '''A city with only one row of history produces NaN for pm2_5_prev_1h
+    without crashing'''
+    df = _make_df([
+        (1, 0, 10.0),   # the only row of history for city 1
+    ])
+    result = add_lag_features(df)
+    assert pd.isna(result.iloc[0]['pm2_5_prev_1h'])
+
+
+def test_rolling_handles_single_row_city():
+    '''A city with only one row gets its own value as the rolling mean
+    (min_periods=1 semantics — no NaN from short history).'''
+    df = _make_df([
+        (1, 0, 42.0),
+    ])
+    result = add_rolling_features(df)
+    assert result.iloc[0]['pm2_5_roll_3h'] == 42.0
+    assert result.iloc[0]['pm2_5_roll_12h'] == 42.0
+
+
+def test_features_do_not_leak_between_cities():
+    '''Lag and rolling features are computed per city_id, so one city's history
+    never leaks into another city's features.'''
+    df = _make_df([
+        (1, 0, 10.0),
+        (1, 1, 20.0),
+        (2, 0, 1000.0),
+        (2, 1, 2000.0),
+    ])
+    result = add_ml_features(df)
+
+    # City 1's lag feature is based on its own history, not city 2's
+    assert result[result['city_id'] == 1].iloc[1]['pm2_5_prev_1h'] == 10.0
+
+    # City 2's lag feature is based on its own history, not city 1's
+    assert result[result['city_id'] == 2].iloc[1]['pm2_5_prev_1h'] == 1000.0
+
+    # City 1's rolling features are based on its own history, not city 2's
+    city_1_roll_3h = result[result['city_id'] == 1]['pm2_5_roll_3h'].tolist()
+    assert city_1_roll_3h == [10.0, (10.0 + 20.0) / 2]
+
+    # City 2's rolling features are based on its own history, not city 1's
+    city_2_roll_3h = result[result['city_id'] == 2]['pm2_5_roll_3h'].tolist()
+    assert city_2_roll_3h == [1000.0, (1000.0 + 2000.0) / 2]
+
+
+def test_features_are_deterministic_under_shuffle():
+    '''Output features are identical regardless of input row order, since
+    features are computed per city_id with a deterministic sort by ts.'''
+    df_ordered = _make_df([
+        (1, 0, 10.0),
+        (1, 1, 20.0),
+        (1, 2, 30.0),
+        (2, 0, 1000.0),
+        (2, 1, 2000.0),
+        (2, 2, 3000.0),
+    ])
+    df_shuffled = df_ordered.sample(frac=1, random_state=42).reset_index(drop=True)
+
+    result_ordered = add_ml_features(df_ordered).sort_values(['city_id', 'ts']).reset_index(drop=True)
+    result_shuffled = add_ml_features(df_shuffled).sort_values(['city_id', 'ts']).reset_index(drop=True)
+
+    pd.testing.assert_frame_equal(result_ordered, result_shuffled)
+
+
+def test_raises_on_missing_required_column():
+    '''add_ml_features raises a KeyError if the input DataFrame is missing any
+    required column.'''
+    df = pd.DataFrame({
+        'city_id': [1],
+        'ts': [pd.Timestamp("2026-04-05T00:00:00Z")],
+        # 'pm2_5' column is missing
+    })
+    with pytest.raises(KeyError, match="missing required column"):
+        add_ml_features(df)
+
+
+def test_input_dataframe_is_not_mutated():
+    '''The input DataFrame is not mutated by add_ml_features, add_lag_features,
+    or add_rolling_features — a new DataFrame with added columns is returned.'''
+    df = _make_df([
+        (1, 0, 10.0),
+        (1, 1, 20.0),
+    ])
+    df_before = df.copy()
+    _ = add_ml_features(df)
+    _ = add_lag_features(df)
+    _ = add_rolling_features(df)
+    pd.testing.assert_frame_equal(df, df_before)


### PR DESCRIPTION
**What**

Adds pipeline/ml/features.py with add_ml_features(df): appends 5 deterministic features: hour_of_day, day_of_week, pm2_5_prev_1h, pm2_5_roll_3h, pm2_5_roll_12h. Computed per city_id, input never mutated.

**Why**
Story scope: the feature-engineering logic the local risk model will consume. Lives in pipeline/ml/ so the model can call it directly without coupling ETL transform to model concerns.

**Tests**
8 cases in tests/test_features.py, all passed, 1.86s: 

- column shape
- lag NaN at first row
- single-row cities (lag + rolling)
- no cross-city leakage (non-overlapping value ranges)
- determinism under shuffle (assert_frame_equal)
- KeyError on missing columns, no input mutation.

AIR-014.2: Implement feature engineering for ML enrichment #105