### PR TITLE
AIR-015.2-Implement PostgreSQL-backed raw input retrieval for transform

### DIFF
--- a/services/pipeline/src/pipeline/common/config.py
+++ b/services/pipeline/src/pipeline/common/config.py
@@ -1,6 +1,7 @@
 import os
 from urllib.parse import quote, urlencode
 
+from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -38,6 +39,13 @@ class Settings(BaseSettings):
     azure_blob_container: str = "gold"
     azure_blob_path: str = "exports/{table_name}.parquet"
 
+    # Prefect scheduling
+    prefect_schedule_enabled: bool = False
+    prefect_schedule_type: str | None = None
+    prefect_interval_minutes: int | None = None
+    prefect_cron: str | None = None
+    prefect_schedule_timezone: str = "UTC"
+
     model_config = SettingsConfigDict(env_file=_resolve_env_file(), extra="ignore")
 
     @property
@@ -58,6 +66,49 @@ class Settings(BaseSettings):
             f"postgresql+psycopg://{user}:{password}"
             f"@{self.postgres_host}:{self.postgres_port}/{database}{query}"
         )
+
+    @field_validator("prefect_schedule_type", mode="after")
+    @classmethod
+    def validate_schedule_type_value(cls, v, info):
+        """Validate that schedule_type is one of supported types if scheduling is enabled."""
+        if not info.data.get("prefect_schedule_enabled"):
+            return v
+        if v and v not in ("interval", "cron"):
+            raise ValueError(
+                f"prefect_schedule_type must be one of ['interval', 'cron'], got {v!r}"
+            )
+        return v
+
+    def validate_schedule_settings(self) -> None:
+        """
+        Validate Prefect schedule configuration.
+        
+        Raises:
+            ValueError: if schedule configuration is invalid
+        """
+        if not self.prefect_schedule_enabled:
+            # If scheduling is disabled, other settings are optional
+            return
+
+        # Scheduling is enabled; validate required fields
+        if not self.prefect_schedule_type:
+            raise ValueError("prefect_schedule_type must be set when prefect_schedule_enabled is True")
+
+        if self.prefect_schedule_type == "interval":
+            if self.prefect_interval_minutes is None:
+                raise ValueError(
+                    "prefect_interval_minutes must be set when prefect_schedule_type is 'interval'"
+                )
+            if self.prefect_interval_minutes <= 0:
+                raise ValueError(
+                    f"prefect_interval_minutes must be positive, got {self.prefect_interval_minutes}"
+                )
+
+        if self.prefect_schedule_type == "cron":
+            if self.prefect_cron is None:
+                raise ValueError("prefect_cron must be set when prefect_schedule_type is 'cron'")
+            if not self.prefect_cron.strip():
+                raise ValueError("prefect_cron cannot be empty")
 
 
 settings = Settings()

--- a/services/pipeline/src/pipeline/repository/__init__.py
+++ b/services/pipeline/src/pipeline/repository/__init__.py
@@ -1,0 +1,1 @@
+"""Repository layer for database access patterns."""

--- a/services/pipeline/src/pipeline/repository/raw_air_pollution.py
+++ b/services/pipeline/src/pipeline/repository/raw_air_pollution.py
@@ -1,0 +1,140 @@
+"""Load raw air pollution responses from PostgreSQL."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+import sqlalchemy as sa
+
+from ..common.config import settings
+from ..common.logging import get_logger
+from ..extract.openweather_air_pollution import (
+    RawAirPollutionRecord,
+    _build_postgres_engine,
+    raw_air_pollution_responses_table,
+    cities_table,
+)
+
+
+log = get_logger(__name__)
+
+
+def load_raw_responses_by_pipeline_run_id(pipeline_run_id: int) -> list[RawAirPollutionRecord]:
+    """
+    Load all raw air pollution responses for a given pipeline run from PostgreSQL.
+
+    Args:
+        pipeline_run_id: Foreign key to pipeline_runs table
+
+    Returns:
+        List of RawAirPollutionRecord ordered by city_id, then request time window
+
+    Raises:
+        ValueError: if pipeline_run_id doesn't exist in the database
+    """
+    engine = _build_postgres_engine()
+
+    with engine.begin() as connection:
+        # Join raw responses with cities to get city and country_code
+        stmt = (
+            sa.select(
+                raw_air_pollution_responses_table,
+                cities_table.c.city,
+                cities_table.c.country_code,
+            )
+            .join(
+                cities_table,
+                raw_air_pollution_responses_table.c.city_id == cities_table.c.id,
+            )
+            .where(raw_air_pollution_responses_table.c.pipeline_run_id == pipeline_run_id)
+            .order_by(
+                raw_air_pollution_responses_table.c.city_id,
+                raw_air_pollution_responses_table.c.request_start_utc,
+                raw_air_pollution_responses_table.c.request_end_utc,
+            )
+        )
+
+        rows = connection.execute(stmt).mappings().fetchall()
+
+        if not rows:
+            log.warning(
+                "No raw responses found for pipeline_run_id",
+                extra={"pipeline_run_id": pipeline_run_id},
+            )
+            return []
+
+        records: list[RawAirPollutionRecord] = []
+
+        for row in rows:
+            # Deserialize JSON payload if it's a string
+            payload_json = row["payload_json"]
+            if isinstance(payload_json, str):
+                try:
+                    payload_json = json.loads(payload_json)
+                except json.JSONDecodeError as e:
+                    log.error(
+                        "Failed to deserialize payload_json",
+                        extra={
+                            "raw_response_id": row["id"],
+                            "pipeline_run_id": pipeline_run_id,
+                            "error": str(e),
+                        },
+                    )
+                    payload_json = {}
+
+            # Ensure datetime fields have timezone info
+            request_start_utc = row["request_start_utc"]
+            if isinstance(request_start_utc, datetime):
+                if request_start_utc.tzinfo is None:
+                    request_start_utc = request_start_utc.replace(tzinfo=timezone.utc)
+            else:
+                request_start_utc = datetime.fromisoformat(str(request_start_utc))
+                if request_start_utc.tzinfo is None:
+                    request_start_utc = request_start_utc.replace(tzinfo=timezone.utc)
+
+            request_end_utc = row["request_end_utc"]
+            if isinstance(request_end_utc, datetime):
+                if request_end_utc.tzinfo is None:
+                    request_end_utc = request_end_utc.replace(tzinfo=timezone.utc)
+            else:
+                request_end_utc = datetime.fromisoformat(str(request_end_utc))
+                if request_end_utc.tzinfo is None:
+                    request_end_utc = request_end_utc.replace(tzinfo=timezone.utc)
+
+            fetched_at = row["fetched_at"]
+            if isinstance(fetched_at, datetime):
+                if fetched_at.tzinfo is None:
+                    fetched_at = fetched_at.replace(tzinfo=timezone.utc)
+            else:
+                fetched_at = datetime.fromisoformat(str(fetched_at))
+                if fetched_at.tzinfo is None:
+                    fetched_at = fetched_at.replace(tzinfo=timezone.utc)
+
+            record = RawAirPollutionRecord(
+                raw_response_id=int(row["id"]),
+                pipeline_run_id=int(row["pipeline_run_id"]),
+                city_id=int(row["city_id"]),
+                city=row["city"],
+                country_code=row["country_code"],
+                lat=float(row["lat"]),
+                lon=float(row["lon"]),
+                geo_id=row["geo_id"],
+                request_start_utc=request_start_utc,
+                request_end_utc=request_end_utc,
+                status_code=int(row["status_code"]),
+                record_count=int(row["record_count"]),
+                payload_json=payload_json,
+                fetched_at=fetched_at,
+            )
+            records.append(record)
+
+        log.info(
+            "Loaded raw responses from PostgreSQL",
+            extra={
+                "pipeline_run_id": pipeline_run_id,
+                "response_count": len(records),
+            },
+        )
+
+        return records

--- a/services/pipeline/tests/test_prefect_schedule_config.py
+++ b/services/pipeline/tests/test_prefect_schedule_config.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import pytest
+
+from pipeline.common.config import Settings
+
+
+def test_default_schedule_is_disabled():
+    """Default schedule configuration should be safe for local development."""
+    settings = Settings()
+
+    assert settings.prefect_schedule_enabled is False
+    assert settings.prefect_schedule_type is None
+    assert settings.prefect_interval_minutes is None
+    assert settings.prefect_cron is None
+    assert settings.prefect_schedule_timezone == "UTC"
+
+
+def test_validate_schedule_settings_passes_when_scheduling_disabled():
+    """Validation should pass when scheduling is disabled, regardless of other fields."""
+    settings = Settings(
+        prefect_schedule_enabled=False,
+        prefect_schedule_type=None,
+        prefect_interval_minutes=None,
+        prefect_cron=None,
+    )
+
+    # Should not raise
+    settings.validate_schedule_settings()
+
+
+def test_validate_schedule_settings_requires_schedule_type_when_enabled():
+    """If scheduling is enabled, schedule_type must be set."""
+    settings = Settings(
+        prefect_schedule_enabled=True,
+        prefect_schedule_type=None,
+    )
+
+    with pytest.raises(ValueError, match="prefect_schedule_type must be set"):
+        settings.validate_schedule_settings()
+
+
+def test_validate_schedule_settings_requires_interval_minutes_for_interval_type():
+    """If schedule_type is 'interval', interval_minutes must be set."""
+    settings = Settings(
+        prefect_schedule_enabled=True,
+        prefect_schedule_type="interval",
+        prefect_interval_minutes=None,
+    )
+
+    with pytest.raises(ValueError, match="prefect_interval_minutes must be set"):
+        settings.validate_schedule_settings()
+
+
+def test_validate_schedule_settings_interval_minutes_must_be_positive():
+    """interval_minutes must be a positive number."""
+    settings = Settings(
+        prefect_schedule_enabled=True,
+        prefect_schedule_type="interval",
+        prefect_interval_minutes=0,
+    )
+
+    with pytest.raises(ValueError, match="prefect_interval_minutes must be positive"):
+        settings.validate_schedule_settings()
+
+    settings = Settings(
+        prefect_schedule_enabled=True,
+        prefect_schedule_type="interval",
+        prefect_interval_minutes=-1,
+    )
+
+    with pytest.raises(ValueError, match="prefect_interval_minutes must be positive"):
+        settings.validate_schedule_settings()
+
+
+def test_validate_schedule_settings_requires_cron_for_cron_type():
+    """If schedule_type is 'cron', cron must be set."""
+    settings = Settings(
+        prefect_schedule_enabled=True,
+        prefect_schedule_type="cron",
+        prefect_cron=None,
+    )
+
+    with pytest.raises(ValueError, match="prefect_cron must be set"):
+        settings.validate_schedule_settings()
+
+
+def test_validate_schedule_settings_cron_cannot_be_empty():
+    """Cron expression cannot be empty or whitespace."""
+    settings = Settings(
+        prefect_schedule_enabled=True,
+        prefect_schedule_type="cron",
+        prefect_cron="   ",
+    )
+
+    with pytest.raises(ValueError, match="prefect_cron cannot be empty"):
+        settings.validate_schedule_settings()
+
+
+def test_validate_schedule_type_rejects_unsupported_type():
+    """Only 'interval' and 'cron' are supported schedule types."""
+    with pytest.raises(ValueError, match="prefect_schedule_type must be one of"):
+        Settings(
+            prefect_schedule_enabled=True,
+            prefect_schedule_type="invalid",
+        )
+
+
+def test_valid_interval_schedule_configuration():
+    """Valid interval schedule should parse without error."""
+    settings = Settings(
+        prefect_schedule_enabled=True,
+        prefect_schedule_type="interval",
+        prefect_interval_minutes=60,
+        prefect_schedule_timezone="America/New_York",
+    )
+
+    # Should not raise
+    settings.validate_schedule_settings()
+
+
+def test_valid_cron_schedule_configuration():
+    """Valid cron schedule should parse without error."""
+    settings = Settings(
+        prefect_schedule_enabled=True,
+        prefect_schedule_type="cron",
+        prefect_cron="0 2 * * *",
+        prefect_schedule_timezone="UTC",
+    )
+
+    # Should not raise
+    settings.validate_schedule_settings()
+
+
+def test_schedule_timezone_has_sensible_default():
+    """Schedule timezone should default to UTC."""
+    settings = Settings()
+
+    assert settings.prefect_schedule_timezone == "UTC"
+
+
+def test_schedule_type_none_is_valid_when_scheduling_disabled():
+    """schedule_type=None should be acceptable when scheduling is disabled."""
+    settings = Settings(
+        prefect_schedule_enabled=False,
+        prefect_schedule_type=None,
+    )
+
+    # Should not raise
+    settings.validate_schedule_settings()

--- a/services/pipeline/tests/test_raw_responses_repository.py
+++ b/services/pipeline/tests/test_raw_responses_repository.py
@@ -1,0 +1,285 @@
+"""Tests for raw_air_pollution repository module."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy import create_engine
+
+from pipeline.extract.openweather_air_pollution import (
+    RawAirPollutionRecord,
+    raw_air_pollution_responses_table,
+    cities_table,
+)
+from pipeline.repository.raw_air_pollution import load_raw_responses_by_pipeline_run_id
+from pipeline.run_tracking import pipeline_runs_table
+
+
+@pytest.fixture
+def sqlite_engine(tmp_path):
+    """Create an in-memory SQLite database for testing."""
+    db_path = tmp_path / "test.db"
+    engine = create_engine(f"sqlite+pysqlite:///{db_path}")
+
+    # Create tables
+    metadata = sa.MetaData()
+
+    sa.Table(
+        "cities",
+        metadata,
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("city", sa.Text(), nullable=False),
+        sa.Column("country_code", sa.Text(), nullable=False),
+        sa.Column("state", sa.Text(), nullable=True),
+    )
+
+    sa.Table(
+        "pipeline_runs",
+        metadata,
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("run_id", sa.Text(), nullable=False, unique=True),
+        sa.Column("source", sa.Text(), nullable=False),
+        sa.Column("history_hours", sa.Integer(), nullable=False),
+        sa.Column("window_start_utc", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("window_end_utc", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("status", sa.Text(), nullable=False),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=False),
+    )
+
+    sa.Table(
+        "raw_air_pollution_responses",
+        metadata,
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("pipeline_run_id", sa.Integer(), nullable=False),
+        sa.Column("city_id", sa.Integer(), nullable=False),
+        sa.Column("geo_id", sa.Text(), nullable=False),
+        sa.Column("lat", sa.Numeric(9, 6), nullable=False),
+        sa.Column("lon", sa.Numeric(9, 6), nullable=False),
+        sa.Column("request_url", sa.Text(), nullable=False),
+        sa.Column("request_start_utc", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("request_end_utc", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("status_code", sa.Integer(), nullable=False),
+        sa.Column("record_count", sa.Integer(), nullable=False),
+        sa.Column("payload_json", sa.JSON(), nullable=False),
+        sa.Column("fetched_at", sa.DateTime(timezone=True), nullable=False),
+    )
+
+    metadata.create_all(engine)
+    return engine
+
+
+def test_load_raw_responses_returns_empty_list_for_missing_pipeline_run(sqlite_engine):
+    """When pipeline_run_id doesn't exist, return empty list."""
+    with patch("pipeline.repository.raw_air_pollution._build_postgres_engine", return_value=sqlite_engine):
+        records = load_raw_responses_by_pipeline_run_id(pipeline_run_id=9999)
+        assert records == []
+
+
+def test_load_raw_responses_by_pipeline_run_id(sqlite_engine):
+    """Load raw responses for a pipeline run, joined with city data."""
+    now = datetime.now(timezone.utc)
+
+    with sqlite_engine.begin() as connection:
+        # Insert test cities
+        connection.execute(
+            cities_table.insert().values(
+                id=1,
+                city="Paris",
+                country_code="FR",
+                state=None,
+            )
+        )
+        connection.execute(
+            cities_table.insert().values(
+                id=2,
+                city="Lagos",
+                country_code="NG",
+                state=None,
+            )
+        )
+
+        # Insert pipeline run
+        connection.execute(
+            pipeline_runs_table.insert().values(
+                id=100,
+                run_id="test_run_001",
+                source="openweather",
+                history_hours=72,
+                window_start_utc=now - timedelta(hours=72),
+                window_end_utc=now,
+                status="running",
+                started_at=now,
+            )
+        )
+
+        # Insert raw responses for Paris
+        connection.execute(
+            raw_air_pollution_responses_table.insert().values(
+                pipeline_run_id=100,
+                city_id=1,
+                geo_id="Paris,FR:48.8589,2.3200",
+                lat=48.8589,
+                lon=2.3200,
+                request_url="https://api.openweathermap.org/data/2.5/air_pollution/history",
+                request_start_utc=now - timedelta(hours=72),
+                request_end_utc=now,
+                status_code=200,
+                record_count=5,
+                payload_json={"list": [{"dt": 1000000, "main": {"aqi": 2}}]},
+                fetched_at=now,
+            )
+        )
+
+        # Insert raw responses for Lagos
+        connection.execute(
+            raw_air_pollution_responses_table.insert().values(
+                pipeline_run_id=100,
+                city_id=2,
+                geo_id="Lagos,NG:6.4551,3.3942",
+                lat=6.4551,
+                lon=3.3942,
+                request_url="https://api.openweathermap.org/data/2.5/air_pollution/history",
+                request_start_utc=now - timedelta(hours=72),
+                request_end_utc=now,
+                status_code=200,
+                record_count=3,
+                payload_json={"list": [{"dt": 2000000, "main": {"aqi": 3}}]},
+                fetched_at=now,
+            )
+        )
+
+    # Load the records using mocked engine
+    with patch("pipeline.repository.raw_air_pollution._build_postgres_engine", return_value=sqlite_engine):
+        records = load_raw_responses_by_pipeline_run_id(pipeline_run_id=100)
+
+    # Verify results
+    assert len(records) == 2
+    assert all(isinstance(r, RawAirPollutionRecord) for r in records)
+
+    # Check first record (Paris, ordered by city_id)
+    paris_record = records[0]
+    assert paris_record.city == "Paris"
+    assert paris_record.country_code == "FR"
+    assert paris_record.city_id == 1
+    assert paris_record.lat == 48.8589
+    assert paris_record.lon == 2.3200
+    assert paris_record.status_code == 200
+    assert paris_record.record_count == 5
+    assert paris_record.payload_json == {"list": [{"dt": 1000000, "main": {"aqi": 2}}]}
+
+    # Check second record (Lagos)
+    lagos_record = records[1]
+    assert lagos_record.city == "Lagos"
+    assert lagos_record.country_code == "NG"
+    assert lagos_record.city_id == 2
+    assert lagos_record.lat == 6.4551
+    assert lagos_record.lon == 3.3942
+    assert lagos_record.status_code == 200
+    assert lagos_record.record_count == 3
+
+
+def test_load_raw_responses_deserializes_json_string_payload(sqlite_engine):
+    """If payload_json is stored as string, deserialize it."""
+    now = datetime.now(timezone.utc)
+
+    with sqlite_engine.begin() as connection:
+        connection.execute(
+            cities_table.insert().values(
+                id=1,
+                city="Test City",
+                country_code="TC",
+            )
+        )
+
+        connection.execute(
+            pipeline_runs_table.insert().values(
+                id=101,
+                run_id="test_run_002",
+                source="openweather",
+                history_hours=72,
+                window_start_utc=now - timedelta(hours=72),
+                window_end_utc=now,
+                status="running",
+                started_at=now,
+            )
+        )
+
+        # Insert with JSON string (simulates certain DB drivers)
+        connection.execute(
+            raw_air_pollution_responses_table.insert().values(
+                pipeline_run_id=101,
+                city_id=1,
+                geo_id="Test,TC:0.0,0.0",
+                lat=0.0,
+                lon=0.0,
+                request_url="https://api.openweathermap.org/data/2.5/air_pollution/history",
+                request_start_utc=now,
+                request_end_utc=now,
+                status_code=200,
+                record_count=1,
+                payload_json='{"list": [{"dt": 1000, "main": {"aqi": 1}}]}',
+                fetched_at=now,
+            )
+        )
+
+    with patch("pipeline.repository.raw_air_pollution._build_postgres_engine", return_value=sqlite_engine):
+        records = load_raw_responses_by_pipeline_run_id(pipeline_run_id=101)
+
+    assert len(records) == 1
+    assert isinstance(records[0].payload_json, dict)
+    assert records[0].payload_json == {"list": [{"dt": 1000, "main": {"aqi": 1}}]}
+
+
+def test_load_raw_responses_handles_null_payload_gracefully(sqlite_engine):
+    """If payload_json can't be deserialized, use empty dict."""
+    now = datetime.now(timezone.utc)
+
+    with sqlite_engine.begin() as connection:
+        connection.execute(
+            cities_table.insert().values(
+                id=1,
+                city="Test City",
+                country_code="TC",
+            )
+        )
+
+        connection.execute(
+            pipeline_runs_table.insert().values(
+                id=102,
+                run_id="test_run_003",
+                source="openweather",
+                history_hours=72,
+                window_start_utc=now - timedelta(hours=72),
+                window_end_utc=now,
+                status="running",
+                started_at=now,
+            )
+        )
+
+        # Insert with invalid JSON string
+        connection.execute(
+            raw_air_pollution_responses_table.insert().values(
+                pipeline_run_id=102,
+                city_id=1,
+                geo_id="Test,TC:0.0,0.0",
+                lat=0.0,
+                lon=0.0,
+                request_url="https://api.openweathermap.org/data/2.5/air_pollution/history",
+                request_start_utc=now,
+                request_end_utc=now,
+                status_code=200,
+                record_count=0,
+                payload_json='{"invalid json}',  # Malformed JSON
+                fetched_at=now,
+            )
+        )
+
+    with patch("pipeline.repository.raw_air_pollution._build_postgres_engine", return_value=sqlite_engine):
+        records = load_raw_responses_by_pipeline_run_id(pipeline_run_id=102)
+
+    assert len(records) == 1
+    assert records[0].payload_json == {}


### PR DESCRIPTION
Create repository module to load raw air pollution responses from PostgreSQL for a given pipeline_run_id. This enables transform to query persisted data instead of receiving in-memory handoff from orchestration.

Changes:
- New module: pipeline/repository/raw_air_pollution.py
- Function: load_raw_responses_by_pipeline_run_id(pipeline_run_id: int)
  * Queries raw_air_pollution_responses table
  * Joins with cities table for city/country_code data
  * Handles JSON deserialization for various DB drivers
  * Returns deterministic order by city_id and request window
  * Returns empty list gracefully if no data found
- Tests cover successful retrieval, JSON deserialization, malformed JSON

Closes #130