### PR TITLE
AIR-013.6 Add dashboard Azure deployment workflow

### DIFF
--- a/.github/workflows/dashboard-azure-deploy.yml
+++ b/.github/workflows/dashboard-azure-deploy.yml
@@ -1,0 +1,54 @@
+name: Deploy Dashboard to Azure App Service
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/dashboard-azure-deploy.yml"
+      - "services/dashboard/**"
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  AZURE_WEBAPP_NAME: city-air-tracker-dashboard
+  IMAGE_NAME: ghcr.io/code-the-dream-school/city-air-tracker-dashboard
+
+jobs:
+  build-and-deploy:
+    name: Build and deploy dashboard container
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Sign in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and publish dashboard image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: services/dashboard/Dockerfile
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ github.sha }}
+            ${{ env.IMAGE_NAME }}:latest
+
+      - name: Deploy dashboard image to Azure App Service
+        uses: azure/webapps-deploy@v3
+        with:
+          app-name: ${{ env.AZURE_WEBAPP_NAME }}
+          publish-profile: ${{ secrets.AZURE_DASHBOARD_PUBLISH_PROFILE }}
+          images: ${{ env.IMAGE_NAME }}:${{ github.sha }}

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Use `docs/setup/local_postgresql_first_workflow.md` for the consolidated local P
 
 Use `docs/setup/azure_postgresql_configuration.md` for managed Azure Database for PostgreSQL configuration guidance.
 Use `docs/setup/environment_profiles_guide.md` to keep separate local and Azure env files without overwriting your normal Docker settings.
+Use `docs/setup/dashboard_azure_deployment.md` for the GitHub Actions to Azure App Service dashboard deployment flow.
 Use `bash scripts/generate_env_profiles.sh` to create `.env.local` and `.env.azure` from the tracked templates in `configs/env/`.
 Use `ENV_FILE=.env.azure ...` when you want to run the app, migrations, or Docker Compose against the Azure profile.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ Use these docs when you want to install, run, debug, or validate the project loc
 - `setup/environment_profiles_guide.md`
 - `setup/docker_and_compose_walkthrough.md`
 - `setup/github_quality_gates_setup.md`
+- `setup/dashboard_azure_deployment.md`
 
 ## Collaboration
 

--- a/docs/setup/dashboard_azure_deployment.md
+++ b/docs/setup/dashboard_azure_deployment.md
@@ -1,0 +1,125 @@
+# Dashboard Azure Deployment
+
+This guide explains how the React dashboard is deployed from GitHub to Azure
+App Service.
+
+The dashboard deployment has two parts:
+
+- a GitHub Actions workflow in `.github/workflows/dashboard-azure-deploy.yml`
+- Azure App Service configuration and GitHub repository secrets
+
+## Why the workflow lives in `.github/workflows`
+
+GitHub Actions only discovers workflow files from the repository's
+`.github/workflows/` directory.
+
+The dashboard deployment workflow is:
+
+```text
+.github/workflows/dashboard-azure-deploy.yml
+```
+
+## What the workflow does
+
+When the workflow runs, it:
+
+1. checks out the repository
+2. builds the dashboard container using `services/dashboard/Dockerfile`
+3. publishes the image to GitHub Container Registry
+4. deploys that image to Azure App Service
+
+The published image is named:
+
+```text
+ghcr.io/code-the-dream-school/city-air-tracker-dashboard
+```
+
+## When the workflow runs
+
+The workflow runs automatically after changes are merged to `main` when those
+changes affect:
+
+- `.github/workflows/dashboard-azure-deploy.yml`
+- `services/dashboard/**`
+
+It can also be started manually from the GitHub Actions tab with
+`workflow_dispatch`.
+
+## Required GitHub secret
+
+Create this repository secret in GitHub:
+
+```text
+AZURE_DASHBOARD_PUBLISH_PROFILE
+```
+
+To get the value from Azure:
+
+1. Open the Azure Portal.
+2. Open the dashboard App Service.
+3. Confirm the App Service name is `city-air-tracker-dashboard`.
+4. Click `Get publish profile`.
+5. Open the downloaded publish profile file.
+6. Copy the entire file contents.
+7. In GitHub, open the repository.
+8. Go to `Settings` -> `Secrets and variables` -> `Actions`.
+9. Create a new repository secret named `AZURE_DASHBOARD_PUBLISH_PROFILE`.
+10. Paste the publish profile contents as the secret value.
+
+## Required Azure App Service settings
+
+Set the dashboard runtime environment variables in Azure App Service under:
+
+`Settings` -> `Environment variables`
+
+Use either `DATABASE_URL` or the individual PostgreSQL settings.
+
+Option A:
+
+```dotenv
+DATABASE_URL=postgresql+psycopg://USER:PASSWORD@HOST:5432/cityair
+DASHBOARD_CACHE_TTL_SECONDS=60
+PORT=8501
+```
+
+Option B:
+
+```dotenv
+POSTGRES_HOST=YOUR_SERVER.postgres.database.azure.com
+POSTGRES_PORT=5432
+POSTGRES_DB=cityair
+POSTGRES_USER=YOUR_USER@YOUR_SERVER
+POSTGRES_PASSWORD=YOUR_PASSWORD
+DASHBOARD_CACHE_TTL_SECONDS=60
+PORT=8501
+```
+
+For Azure Database for PostgreSQL, the username commonly includes the server
+name, such as `appuser@myserver`.
+
+## App Service name
+
+The workflow currently targets this Azure App Service:
+
+```text
+city-air-tracker-dashboard
+```
+
+If the Azure App Service is renamed, update `AZURE_WEBAPP_NAME` in
+`.github/workflows/dashboard-azure-deploy.yml`.
+
+## Verification
+
+After the workflow runs:
+
+1. Open the GitHub Actions run and confirm the build and deploy steps passed.
+2. Open the Azure App Service overview page.
+3. Restart the app if Azure prompts for it.
+4. Open the App Service URL.
+5. Confirm the dashboard loads.
+6. Confirm `/api/health` returns a healthy response.
+7. Confirm `/api/dashboard` returns data or an empty dashboard payload.
+
+If the site loads but the dashboard API fails, check the App Service logs and
+confirm the PostgreSQL environment variables point to the Azure PostgreSQL
+server.


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow to build and deploy the dashboard container to Azure App Service.

Also adds deployment documentation covering the required Azure publish profile secret, App Service settings, and verification steps.